### PR TITLE
SpringSecuriy 설정 및 mysql 연동

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/config/SecurityConfig.java
+++ b/src/main/java/com/yangsunkue/suncar/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.yangsunkue.suncar.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Security 설정 클래스입니다.
+ *
+ * 초기 개발 편의를 위해서,
+ * 모든 요청에 대한 인증 및 csrf 공격 보호를 비활성화 했습니다.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/**").permitAll()
+                )
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/yangsunkue/suncar/config/SecurityConfig.java
+++ b/src/main/java/com/yangsunkue/suncar/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -25,5 +27,10 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable());
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/yangsunkue/suncar/controller/auth/AuthController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/auth/AuthController.java
@@ -1,0 +1,33 @@
+package com.yangsunkue.suncar.controller;
+
+import com.yangsunkue.suncar.dto.ResponseDto;
+import com.yangsunkue.suncar.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 인증 관련 컨트롤러 입니다.
+ */
+@RestController
+@RequestMapping("/auth")
+@ResponseStatus(HttpStatus.OK)
+@RequiredArgsConstructor
+public class AuthController {
+
+//    private final AuthService authService;
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "hello";
+    }
+
+    @PostMapping("signup")
+    @Transactional
+    public ResponseEntity<ResponseDto<User>> signUp() {
+
+        
+    }
+}

--- a/src/main/java/com/yangsunkue/suncar/dto/ResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/ResponseDto.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.dto;public class ResponseDto {
+}

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/SignUpRequestDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/SignUpRequestDto.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.dto.auth;public class SignUpRequestDto {
+}

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/SignUpResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/SignUpResponseDto.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.dto.auth;public class SignUpResponseDto {
+}

--- a/src/main/java/com/yangsunkue/suncar/entity/user/User.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/user/User.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.entity.user;public class User {
+}

--- a/src/main/java/com/yangsunkue/suncar/enums/UserRole.java
+++ b/src/main/java/com/yangsunkue/suncar/enums/UserRole.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.enums;public class UserRole {
+}

--- a/src/main/java/com/yangsunkue/suncar/exception/BaseException.java
+++ b/src/main/java/com/yangsunkue/suncar/exception/BaseException.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.exception;public class BaseException {
+}

--- a/src/main/java/com/yangsunkue/suncar/exception/dto/ErrorResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/exception/dto/ErrorResponseDto.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.exception;public class ErrorResponseDto {
+}

--- a/src/main/java/com/yangsunkue/suncar/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/yangsunkue/suncar/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.exception.handler;public class GlobalExceptionHandler {
+}

--- a/src/main/java/com/yangsunkue/suncar/repository/user/UserRepository.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/user/UserRepository.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.repository.user;public interface UserRepository {
+}

--- a/src/main/java/com/yangsunkue/suncar/service/auth/AuthService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/auth/AuthService.java
@@ -1,0 +1,2 @@
+package com.yangsunkue.suncar.service.auth;public class AuthService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=suncar
+
+spring.datasource.url=jdbc:mysql://localhost:3307/suncar
+spring.datasource.username=root
+spring.datasource.password=0000
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
- 초기 개발 편의를 위하여 엔드포인트 인증 및 CSRF 공격 방어 비활성화 설정 추가
- SpringSecurity에 패스워드 해시를 위한 BCrypt 추가, mysql 연동을 위한 application.properties 파일 설정

지금은 로컬DB라 상관없긴 하지만, db접속정보 노출되므로 추후 환경변수로 관리할 필요 있음.