### PR TITLE
Refactor: DTO 패키지 구조 개선 -> request/response로 세분화

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/controller/auth/AuthController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/auth/AuthController.java
@@ -2,10 +2,10 @@ package com.yangsunkue.suncar.controller.auth;
 
 import com.yangsunkue.suncar.common.constant.ResponseMessages;
 import com.yangsunkue.suncar.dto.ResponseDto;
-import com.yangsunkue.suncar.dto.auth.LoginRequestDto;
-import com.yangsunkue.suncar.dto.auth.LoginResponseDto;
-import com.yangsunkue.suncar.dto.auth.SignUpRequestDto;
-import com.yangsunkue.suncar.dto.auth.SignUpResponseDto;
+import com.yangsunkue.suncar.dto.auth.request.LoginRequestDto;
+import com.yangsunkue.suncar.dto.auth.response.LoginResponseDto;
+import com.yangsunkue.suncar.dto.auth.request.SignUpRequestDto;
+import com.yangsunkue.suncar.dto.auth.response.SignUpResponseDto;
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
@@ -3,21 +3,14 @@ package com.yangsunkue.suncar.controller.car;
 import com.yangsunkue.suncar.common.constant.ResponseMessages;
 import com.yangsunkue.suncar.dto.ResponseDto;
 import com.yangsunkue.suncar.dto.car.CarListResponseDto;
-import com.yangsunkue.suncar.dto.car.RegisterCarResponseDto;
 import com.yangsunkue.suncar.service.facade.CarManagementService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.math.BigDecimal;
-import java.net.URI;
 import java.util.List;
 
 /**

--- a/src/main/java/com/yangsunkue/suncar/controller/user/UserController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/user/UserController.java
@@ -2,8 +2,8 @@ package com.yangsunkue.suncar.controller.user;
 
 import com.yangsunkue.suncar.common.constant.ResponseMessages;
 import com.yangsunkue.suncar.dto.ResponseDto;
-import com.yangsunkue.suncar.dto.user.UserProfileResponseDto;
-import com.yangsunkue.suncar.dto.user.UserProfileUpdateRequestDto;
+import com.yangsunkue.suncar.dto.user.response.UserProfileResponseDto;
+import com.yangsunkue.suncar.dto.user.request.UserProfileUpdateRequestDto;
 import com.yangsunkue.suncar.security.CustomUserDetails;
 import com.yangsunkue.suncar.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/request/LoginRequestDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/request/LoginRequestDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.auth;
+package com.yangsunkue.suncar.dto.auth.request;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/request/SignUpRequestDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/request/SignUpRequestDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.auth;
+package com.yangsunkue.suncar.dto.auth.request;
 
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.common.enums.UserRole;

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/response/LoginResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/response/LoginResponseDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.auth;
+package com.yangsunkue.suncar.dto.auth.response;
 
 import com.yangsunkue.suncar.entity.user.User;
 import lombok.*;

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/response/SignUpResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/response/SignUpResponseDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.auth;
+package com.yangsunkue.suncar.dto.auth.response;
 
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.common.enums.UserRole;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/response/RegisterCarResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/response/RegisterCarResponseDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.car;
+package com.yangsunkue.suncar.dto.car.response;
 
 
 import lombok.Builder;

--- a/src/main/java/com/yangsunkue/suncar/dto/user/request/UserProfileUpdateRequestDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/user/request/UserProfileUpdateRequestDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.user;
+package com.yangsunkue.suncar.dto.user.request;
 
 import lombok.*;
 

--- a/src/main/java/com/yangsunkue/suncar/dto/user/response/UserProfileResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/user/response/UserProfileResponseDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.user;
+package com.yangsunkue.suncar.dto.user.response;
 
 import com.yangsunkue.suncar.common.enums.UserRole;
 import com.yangsunkue.suncar.entity.user.User;

--- a/src/main/java/com/yangsunkue/suncar/entity/user/User.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/user/User.java
@@ -1,6 +1,6 @@
 package com.yangsunkue.suncar.entity.user;
 
-import com.yangsunkue.suncar.dto.user.UserProfileUpdateRequestDto;
+import com.yangsunkue.suncar.dto.user.request.UserProfileUpdateRequestDto;
 import com.yangsunkue.suncar.entity.BaseEntity;
 import com.yangsunkue.suncar.common.enums.UserRole;
 import jakarta.persistence.*;

--- a/src/main/java/com/yangsunkue/suncar/service/auth/AuthService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/auth/AuthService.java
@@ -1,9 +1,8 @@
 package com.yangsunkue.suncar.service.auth;
 
-import com.yangsunkue.suncar.dto.auth.LoginRequestDto;
-import com.yangsunkue.suncar.dto.auth.LoginResponseDto;
-import com.yangsunkue.suncar.dto.auth.SignUpRequestDto;
-import com.yangsunkue.suncar.dto.auth.SignUpResponseDto;
+import com.yangsunkue.suncar.dto.auth.request.LoginRequestDto;
+import com.yangsunkue.suncar.dto.auth.response.LoginResponseDto;
+import com.yangsunkue.suncar.dto.auth.request.SignUpRequestDto;
 import com.yangsunkue.suncar.entity.user.User;
 
 public interface AuthService {

--- a/src/main/java/com/yangsunkue/suncar/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/auth/AuthServiceImpl.java
@@ -1,10 +1,9 @@
 package com.yangsunkue.suncar.service.auth;
 
 import com.yangsunkue.suncar.common.constant.ErrorMessages;
-import com.yangsunkue.suncar.dto.auth.LoginRequestDto;
-import com.yangsunkue.suncar.dto.auth.LoginResponseDto;
-import com.yangsunkue.suncar.dto.auth.SignUpRequestDto;
-import com.yangsunkue.suncar.dto.auth.SignUpResponseDto;
+import com.yangsunkue.suncar.dto.auth.request.LoginRequestDto;
+import com.yangsunkue.suncar.dto.auth.response.LoginResponseDto;
+import com.yangsunkue.suncar.dto.auth.request.SignUpRequestDto;
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.exception.DuplicateResourceException;
 import com.yangsunkue.suncar.exception.NotFoundException;

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementService.java
@@ -1,7 +1,7 @@
 package com.yangsunkue.suncar.service.facade;
 
 import com.yangsunkue.suncar.dto.car.CarListResponseDto;
-import com.yangsunkue.suncar.dto.car.RegisterCarResponseDto;
+import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementServiceImpl.java
@@ -2,7 +2,7 @@ package com.yangsunkue.suncar.service.facade;
 
 import com.yangsunkue.suncar.common.enums.BrandName;
 import com.yangsunkue.suncar.dto.car.CarListResponseDto;
-import com.yangsunkue.suncar.dto.car.RegisterCarResponseDto;
+import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
 import com.yangsunkue.suncar.repository.car.CarListingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/yangsunkue/suncar/service/user/UserService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/user/UserService.java
@@ -1,7 +1,7 @@
 package com.yangsunkue.suncar.service.user;
 
-import com.yangsunkue.suncar.dto.user.UserProfileResponseDto;
-import com.yangsunkue.suncar.dto.user.UserProfileUpdateRequestDto;
+import com.yangsunkue.suncar.dto.user.response.UserProfileResponseDto;
+import com.yangsunkue.suncar.dto.user.request.UserProfileUpdateRequestDto;
 import com.yangsunkue.suncar.security.CustomUserDetails;
 
 public interface UserService {

--- a/src/main/java/com/yangsunkue/suncar/service/user/UserServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/user/UserServiceImpl.java
@@ -1,8 +1,8 @@
 package com.yangsunkue.suncar.service.user;
 
 import com.yangsunkue.suncar.common.constant.ErrorMessages;
-import com.yangsunkue.suncar.dto.user.UserProfileResponseDto;
-import com.yangsunkue.suncar.dto.user.UserProfileUpdateRequestDto;
+import com.yangsunkue.suncar.dto.user.response.UserProfileResponseDto;
+import com.yangsunkue.suncar.dto.user.request.UserProfileUpdateRequestDto;
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.exception.NotFoundException;
 import com.yangsunkue.suncar.repository.user.UserRepository;


### PR DESCRIPTION
- DTO 패키지 구조 세분화
- 기존 : DTO/도메인명/DTO들
- 개선 : DTO/도메인명/request OR response/DTO들

request/response DTO가 아닌 것들은 도메인명 하위에 바로 작성