### PR TITLE
Feat: DTO <-> 엔티티 변환을 위한 매퍼 클래스 도입 및 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ dependencies {
 
 	// Bean Validation API
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 }
 
 // Querydsl 설정

--- a/src/main/java/com/yangsunkue/suncar/controller/auth/AuthController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/auth/AuthController.java
@@ -7,6 +7,7 @@ import com.yangsunkue.suncar.dto.auth.response.LoginResponseDto;
 import com.yangsunkue.suncar.dto.auth.request.SignUpRequestDto;
 import com.yangsunkue.suncar.dto.auth.response.SignUpResponseDto;
 import com.yangsunkue.suncar.entity.user.User;
+import com.yangsunkue.suncar.mapper.UserMapper;
 import com.yangsunkue.suncar.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,6 +29,7 @@ import java.net.URI;
 public class AuthController {
 
     private final AuthService authService;
+    private final UserMapper userMapper;
 
     @GetMapping("/hello")
     public String hello() {
@@ -42,7 +44,7 @@ public class AuthController {
     public ResponseEntity<ResponseDto<SignUpResponseDto>> signUp(@RequestBody SignUpRequestDto dto) {
 
         User created = authService.createUser(dto);
-        SignUpResponseDto userDto = SignUpResponseDto.fromUser(created);
+        SignUpResponseDto userDto = userMapper.toSignUpResponseDto(created);
         ResponseDto<SignUpResponseDto> response = ResponseDto.of(ResponseMessages.USER_CREATED, userDto);
 
         /**

--- a/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
@@ -2,7 +2,7 @@ package com.yangsunkue.suncar.controller.car;
 
 import com.yangsunkue.suncar.common.constant.ResponseMessages;
 import com.yangsunkue.suncar.dto.ResponseDto;
-import com.yangsunkue.suncar.dto.car.CarListResponseDto;
+import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.service.facade.CarManagementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/yangsunkue/suncar/controller/user/UserController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/user/UserController.java
@@ -4,6 +4,7 @@ import com.yangsunkue.suncar.common.constant.ResponseMessages;
 import com.yangsunkue.suncar.dto.ResponseDto;
 import com.yangsunkue.suncar.dto.user.response.UserProfileResponseDto;
 import com.yangsunkue.suncar.dto.user.request.UserProfileUpdateRequestDto;
+import com.yangsunkue.suncar.mapper.UserMapper;
 import com.yangsunkue.suncar.security.CustomUserDetails;
 import com.yangsunkue.suncar.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserMapper userMapper;
 
     /**
      * 현재 사용자 정보를 조회합니다.
@@ -35,7 +37,7 @@ public class UserController {
     public ResponseDto<UserProfileResponseDto> getCurrentUserProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        UserProfileResponseDto userProfile = UserProfileResponseDto.fromUserDetails(userDetails);
+        UserProfileResponseDto userProfile = userMapper.toUserProfileResponseDtoFromUserDetails(userDetails);
         return ResponseDto.of(ResponseMessages.USER_PROFILE_RETRIEVED, userProfile);
     }
 

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/request/SignUpRequestDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/request/SignUpRequestDto.java
@@ -19,15 +19,4 @@ public class SignUpRequestDto {
     private String password;
     private String phoneNumber;
     private UserRole role;
-
-    public static User toEntity(SignUpRequestDto dto, String hashedPassword) {
-        return User.builder()
-                .userId(dto.getUserId())
-                .email(dto.getEmail())
-                .username(dto.getUsername())
-                .passwordHash(hashedPassword)
-                .phoneNumber(dto.getPhoneNumber())
-                .role(dto.getRole())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/response/LoginResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/response/LoginResponseDto.java
@@ -13,12 +13,4 @@ public class LoginResponseDto {
     private String userId;
     private String username;
     private String accessToken;
-
-    public static LoginResponseDto fromUserAndToken(User user, String accessToken) {
-        return LoginResponseDto.builder()
-                .userId(user.getUserId())
-                .username(user.getUsername())
-                .accessToken(accessToken)
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/auth/response/SignUpResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/response/SignUpResponseDto.java
@@ -17,15 +17,4 @@ public class SignUpResponseDto {
     private String username;
     private String phoneNumber;
     private UserRole role;
-
-    public static SignUpResponseDto fromUser(User user) {
-        return SignUpResponseDto.builder()
-                .id(user.getId())
-                .userId(user.getUserId())
-                .email(user.getEmail())
-                .username(user.getUsername())
-                .phoneNumber(user.getPhoneNumber())
-                .role(user.getRole())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentDto.java
@@ -13,19 +13,7 @@ import java.time.LocalDate;
 public class CarAccidentDto {
 
     private Long carId;
-
     private LocalDate accidentDate;
-
     private String accidentType;
-
     private String processingType;
-
-    public static CarAccident toEntity(CarAccidentDto dto) {
-        return CarAccident.builder()
-                .car(Car.builder().id(dto.getCarId()).build())
-                .accidentDate(dto.getAccidentDate())
-                .accidentType(dto.getAccidentType())
-                .processingType(dto.getProcessingType())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentRepairDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentRepairDto.java
@@ -13,28 +13,10 @@ import java.math.BigDecimal;
 public class CarAccidentRepairDto {
 
     private Long accidentId;
-
     private String accidType;
-
     private String totalAmount;
-
     private BigDecimal partsCost;
-
     private BigDecimal laborCost;
-
     private BigDecimal paintingCost;
-
     private BigDecimal insuranceAmount;
-
-    public static CarAccidentRepair toEntity(CarAccidentRepairDto dto) {
-        return CarAccidentRepair.builder()
-                .carAccident(CarAccident.builder().id(dto.getAccidentId()).build())
-                .accidType(dto.getAccidType())
-                .totalAmount(dto.getTotalAmount())
-                .partsCost(dto.getPartsCost())
-                .laborCost(dto.getLaborCost())
-                .paintingCost(dto.getPaintingCost())
-                .insuranceAmount(dto.getInsuranceAmount())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarDto.java
@@ -15,46 +15,16 @@ import java.time.LocalDate;
 public class CarDto {
 
     private Long modelId;
-
     private String carName;
-
     private String carNumber;
-
     private String displacement;
-
     private String fuelType;
-
     private Integer year;
-
     private Integer month;
-
     private String bodyShape;
-
     private String modelType;
-
     private LocalDate firstInsuranceDate;
-
     private String identificationNumber;
-
     private BigDecimal minPrice;
-
     private BigDecimal maxPrice;
-
-    public static Car toEntity(CarDto dto) {
-        return Car.builder()
-                .model(Model.builder().id(dto.getModelId()).build())
-                .carName(dto.getCarName())
-                .carNumber(dto.getCarNumber())
-                .displacement(dto.getDisplacement())
-                .fuelType(dto.getFuelType())
-                .year(dto.getYear())
-                .month(dto.getMonth())
-                .bodyShape(dto.getBodyShape())
-                .modelType(dto.getModelType())
-                .firstInsuranceDate(dto.getFirstInsuranceDate())
-                .identificationNumber(dto.getIdentificationNumber())
-                .minPrice(dto.getMinPrice())
-                .maxPrice(dto.getMaxPrice())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarListingDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarListingDto.java
@@ -15,22 +15,8 @@ import java.math.BigDecimal;
 public class CarListingDto {
 
     private Long carId;
-
     private Long sellerId;
-
     private BigDecimal price;
-
     private String description;
-
     private CarListingStatus status;
-
-    public static CarListing toEntity(CarListingDto dto) {
-        return CarListing.builder()
-                .car(Car.builder().id(dto.getCarId()).build())
-                .user(User.builder().id(dto.getSellerId()).build())
-                .price(dto.getPrice())
-                .description(dto.getDescription())
-                .status(dto.getStatus())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarListingImageDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarListingImageDto.java
@@ -11,16 +11,6 @@ import lombok.*;
 public class CarListingImageDto {
 
     private Long listingId;
-
     private String imageUrl;
-
     private Boolean isPrimary;
-
-    public static CarListingImage toEntity(CarListingImageDto dto) {
-        return CarListingImage.builder()
-                .carListing(CarListing.builder().id(dto.getListingId()).build())
-                .imageUrl(dto.getImageUrl())
-                .isPrimary(dto.getIsPrimary())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarMileageDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarMileageDto.java
@@ -13,19 +13,7 @@ import java.time.LocalDate;
 public class CarMileageDto {
 
     private Long carId;
-
     private Integer distance;
-
     private String provider;
-
     private LocalDate recordDate;
-
-    public static CarMileage toEntity(CarMileageDto dto) {
-        return CarMileage.builder()
-                .car(Car.builder().id(dto.getCarId()).build())
-                .distance(dto.getDistance())
-                .provider(dto.getProvider())
-                .recordDate(dto.getRecordDate())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarOptionDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarOptionDto.java
@@ -12,16 +12,6 @@ import lombok.*;
 public class CarOptionDto {
 
     private Long carId;
-
     private String optionName;
-
     private OptionInstallStatus installStatus;
-
-    public static CarOption toEntity(CarOptionDto dto) {
-        return CarOption.builder()
-                .car(Car.builder().id(dto.getCarId()).build())
-                .optionName(dto.getOptionName())
-                .installStatus(dto.getInstallStatus())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarOwnershipChangeDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarOwnershipChangeDto.java
@@ -13,22 +13,8 @@ import java.time.LocalDate;
 public class CarOwnershipChangeDto {
 
     private Long carId;
-
     private LocalDate changeDate;
-
     private String changeType;
-
     private String carNumber;
-
     private String usagePurpose;
-
-    public static CarOwnershipChange toEntity(CarOwnershipChangeDto dto) {
-        return CarOwnershipChange.builder()
-                .car(Car.builder().id(dto.getCarId()).build())
-                .changeDate(dto.getChangeDate())
-                .changeType(dto.getChangeType())
-                .carNumber(dto.getCarNumber())
-                .usagePurpose(dto.getUsagePurpose())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarUsageDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarUsageDto.java
@@ -11,19 +11,7 @@ import lombok.*;
 public class CarUsageDto {
 
     private Long carId;
-
     private String rentalHistory;
-
     private String businessHistory;
-
     private String governmentHistory;
-
-    public static CarUsage toEntity(CarUsageDto dto) {
-        return CarUsage.builder()
-                .car(Car.builder().id(dto.getCarId()).build())
-                .rentalHistory(dto.getRentalHistory())
-                .businessHistory(dto.getBusinessHistory())
-                .governmentHistory(dto.getGovernmentHistory())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/ModelDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/ModelDto.java
@@ -12,16 +12,6 @@ import lombok.*;
 public class ModelDto {
 
     private BrandName brandName;
-
     private ModelName modelName;
-
     private Boolean isForeign;
-
-    public static Model toEntity(ModelDto dto) {
-        return Model.builder()
-                .brandName(dto.getBrandName())
-                .modelName(dto.getModelName())
-                .isForeign(dto.getIsForeign())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/response/CarListResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/response/CarListResponseDto.java
@@ -1,4 +1,4 @@
-package com.yangsunkue.suncar.dto.car;
+package com.yangsunkue.suncar.dto.car.response;
 
 import lombok.*;
 

--- a/src/main/java/com/yangsunkue/suncar/dto/user/response/UserProfileResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/user/response/UserProfileResponseDto.java
@@ -16,24 +16,4 @@ public class UserProfileResponseDto {
     private String userName;
     private String phoneNumber;
     private UserRole role;
-
-    public static UserProfileResponseDto fromUserDetails(CustomUserDetails userDetails) {
-        return UserProfileResponseDto.builder()
-                .userId(userDetails.getUserId())
-                .email(userDetails.getEmail())
-                .userName(userDetails.getUsername())
-                .phoneNumber(userDetails.getPhoneNumber())
-                .role(userDetails.getRole())
-                .build();
-    }
-
-    public static UserProfileResponseDto fromUser(User user) {
-        return UserProfileResponseDto.builder()
-                .userId(user.getUserId())
-                .email(user.getEmail())
-                .userName(user.getUsername())
-                .phoneNumber(user.getPhoneNumber())
-                .role(user.getRole())
-                .build();
-    }
 }

--- a/src/main/java/com/yangsunkue/suncar/mapper/BaseMapperConfig.java
+++ b/src/main/java/com/yangsunkue/suncar/mapper/BaseMapperConfig.java
@@ -1,0 +1,15 @@
+package com.yangsunkue.suncar.mapper;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * 매퍼 관련 설정 클래스 입니다.
+ * - 매핑되지 않은 필드에 대한 경고를 무시하도록 합니다.
+ */
+@MapperConfig(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface BaseMapperConfig {
+}

--- a/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
+++ b/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
@@ -1,0 +1,34 @@
+package com.yangsunkue.suncar.mapper;
+
+import com.yangsunkue.suncar.dto.car.*;
+import com.yangsunkue.suncar.entity.car.*;
+import org.mapstruct.Mapper;
+
+/**
+ * 차량 관련 모든 엔티티 매퍼 인터페이스 입니다.
+ * Car
+ * CarAccident
+ * CarAccidentRepair
+ * CarListing
+ * CarListingImage
+ * CarMileage
+ * CarOption
+ * CarOwnershipChange
+ * CarUsage
+ * Model
+ */
+@Mapper(config = BaseMapperConfig.class)
+public interface CarMapper {
+
+    /** to Entity */
+    Car fromCarDto(CarDto dto);
+    CarAccident fromAccidentDto(CarAccidentDto dto);
+    CarAccidentRepair fromAccidentRepairDto(CarAccidentRepairDto dto);
+    CarListing fromListingDto(CarListingDto dto);
+    CarListingImage fromListingImageDto(CarListingImageDto dto);
+    CarMileage fromMileageDto(CarMileageDto dto);
+    CarOption fromOptionDto(CarOptionDto dto);
+    CarOwnershipChange fromOwnershipChangeDto(CarOwnershipChangeDto dto);
+    CarUsage fromUsageDto(CarUsageDto dto);
+    Model fromModelDto(ModelDto dto);
+}

--- a/src/main/java/com/yangsunkue/suncar/mapper/UserMapper.java
+++ b/src/main/java/com/yangsunkue/suncar/mapper/UserMapper.java
@@ -1,0 +1,31 @@
+package com.yangsunkue.suncar.mapper;
+
+import com.yangsunkue.suncar.dto.auth.request.SignUpRequestDto;
+import com.yangsunkue.suncar.dto.auth.response.LoginResponseDto;
+import com.yangsunkue.suncar.dto.auth.response.SignUpResponseDto;
+import com.yangsunkue.suncar.dto.user.response.UserProfileResponseDto;
+import com.yangsunkue.suncar.entity.user.User;
+import com.yangsunkue.suncar.security.CustomUserDetails;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * User 엔티티 관련 매퍼 인터페이스 입니다.
+ */
+@Mapper(config = BaseMapperConfig.class)
+public interface UserMapper {
+
+    /** to Entity */
+    @Mapping(source = "passwordHash", target = "passwordHash")
+    User fromSignUpRequestDto(SignUpRequestDto dto, String passwordHash);
+
+
+    /** to Dto */
+    @Mapping(source = "accessToken", target = "accessToken")
+    LoginResponseDto toLoginResponseDto(User user, String accessToken);
+    SignUpResponseDto toSignUpResponseDto(User user);
+    @Mapping(source = "username", target = "userName")
+    UserProfileResponseDto toUserProfileResponseDto(User user);
+    @Mapping(source = "username", target = "userName")
+    UserProfileResponseDto toUserProfileResponseDtoFromUserDetails(CustomUserDetails userDetails);
+}

--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.yangsunkue.suncar.repository.car;
 
-import com.yangsunkue.suncar.dto.car.CarListResponseDto;
+import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 
 import java.util.List;
 

--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImpl.java
@@ -3,7 +3,7 @@ package com.yangsunkue.suncar.repository.car;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.yangsunkue.suncar.dto.car.CarListResponseDto;
+import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.entity.car.*;
 import com.yangsunkue.suncar.repository.support.Querydsl4RepositorySupport;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/yangsunkue/suncar/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/auth/AuthServiceImpl.java
@@ -7,6 +7,7 @@ import com.yangsunkue.suncar.dto.auth.request.SignUpRequestDto;
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.exception.DuplicateResourceException;
 import com.yangsunkue.suncar.exception.NotFoundException;
+import com.yangsunkue.suncar.mapper.UserMapper;
 import com.yangsunkue.suncar.repository.user.UserRepository;
 import com.yangsunkue.suncar.security.CustomUserDetails;
 import com.yangsunkue.suncar.security.JwtUtil;
@@ -29,6 +30,7 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final AuthenticationManager authenticationManager;
+    private final UserMapper userMapper;
 
     /**
      * 일반 회원가입을 진행합니다.
@@ -48,10 +50,10 @@ public class AuthServiceImpl implements AuthService {
 
         // 패스워드 해시 및 엔티티로 변환
         String hashedPassword = passwordEncoder.encode(dto.getPassword());
-        User userEntity = SignUpRequestDto.toEntity(dto, hashedPassword);
+        User user = userMapper.fromSignUpRequestDto(dto, hashedPassword);
 
         // DB 에 저장
-        User saved = userRepository.save(userEntity);
+        User saved = userRepository.save(user);
 
         // 리턴
         return saved;
@@ -85,9 +87,9 @@ public class AuthServiceImpl implements AuthService {
         String token = jwtUtil.generateToken(userDetails);
 
         // responseDto로 변환
-        LoginResponseDto responseDto = LoginResponseDto.fromUserAndToken(user, token);
+        LoginResponseDto loginDto = userMapper.toLoginResponseDto(user, token);
 
         // 리턴
-        return responseDto;
+        return loginDto;
     }
 }

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarAccidentRepairServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarAccidentRepairServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarAccidentRepairDto;
 import com.yangsunkue.suncar.entity.car.CarAccidentRepair;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarAccidentRepairRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 public class CarAccidentRepairServiceImpl implements CarAccidentRepairService {
 
     private final CarAccidentRepairRepository carAccidentRepairRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 사고이력 상세정보를 다수 생성합니다.
@@ -26,7 +28,7 @@ public class CarAccidentRepairServiceImpl implements CarAccidentRepairService {
 
         // 모든 DTO를 엔티티로 변환
         List<CarAccidentRepair> carAccidentRepairs = dtos.stream()
-                .map(CarAccidentRepairDto::toEntity)
+                .map(carMapper::fromAccidentRepairDto)
                 .collect(Collectors.toList());
 
         List<CarAccidentRepair> savedRepairs = carAccidentRepairRepository.saveAll(carAccidentRepairs);

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarAccidentServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarAccidentServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarAccidentDto;
 import com.yangsunkue.suncar.entity.car.CarAccident;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarAccidentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 public class CarAccidentServiceImpl implements CarAccidentService {
 
     private final CarAccidentRepository carAccidentRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 사고이력을 다수 생성합니다.
@@ -29,7 +31,7 @@ public class CarAccidentServiceImpl implements CarAccidentService {
 
         // 모든 DTO를 엔티티로 변환
         List<CarAccident> carAccidents = dtos.stream()
-                .map(CarAccidentDto::toEntity)
+                .map(carMapper::fromAccidentDto)
                 .collect(Collectors.toList());
 
         // DB에 저장하고 리턴

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingImageServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingImageServiceImpl.java
@@ -5,6 +5,7 @@ import com.yangsunkue.suncar.dto.car.CarListingImageDto;
 import com.yangsunkue.suncar.entity.car.CarListingImage;
 import com.yangsunkue.suncar.exception.DuplicateResourceException;
 import com.yangsunkue.suncar.exception.InvalidArgumentException;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarListingImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ import java.util.stream.Collectors;
 public class CarListingImageServiceImpl implements CarListingImageService {
 
     private final CarListingImageRepository carListingImageRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 판매등록 메인 이미지를 생성합니다.
@@ -43,7 +45,7 @@ public class CarListingImageServiceImpl implements CarListingImageService {
         }
 
         // 엔티티 변환 후 DB 저장 및 리턴
-        CarListingImage carListingImageEntity = CarListingImageDto.toEntity(dto);
+        CarListingImage carListingImageEntity = carMapper.fromListingImageDto(dto);
         CarListingImage saved = carListingImageRepository.save(carListingImageEntity);
 
         return saved;
@@ -67,7 +69,7 @@ public class CarListingImageServiceImpl implements CarListingImageService {
 
         // 모든 DTO를 엔티티로 변환 후 DB 저장 및 리턴
         List<CarListingImage> carListingImages = dtos.stream()
-                .map(CarListingImageDto::toEntity)
+                .map(carMapper::fromListingImageDto)
                 .collect(Collectors.toList());
 
         List<CarListingImage> savedImages = carListingImageRepository.saveAll(carListingImages);

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarListingDto;
 import com.yangsunkue.suncar.entity.car.CarListing;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarListingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CarListingServiceImpl implements CarListingService {
 
     private final CarListingRepository carListingRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 판매등록 정보를 생성합니다.
@@ -23,7 +25,7 @@ public class CarListingServiceImpl implements CarListingService {
     @Override
     @Transactional
     public CarListing createListing(CarListingDto dto) {
-        CarListing carListing = CarListingDto.toEntity(dto);
+        CarListing carListing = carMapper.fromListingDto(dto);
         CarListing saved = carListingRepository.save(carListing);
 
         return saved;

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarMileageServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarMileageServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarMileageDto;
 import com.yangsunkue.suncar.entity.car.CarMileage;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarMileageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 public class CarMileageServiceImpl implements CarMileageService {
 
     private final CarMileageRepository carMileageRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 주행거리 정보를 다수 생성합니다.
@@ -29,7 +31,7 @@ public class CarMileageServiceImpl implements CarMileageService {
 
         /** 모든 DTO를 엔티티로 변환 */
         List<CarMileage> carMileages = dtos.stream()
-                .map(CarMileageDto::toEntity)
+                .map(carMapper::fromMileageDto)
                 .collect(Collectors.toList());
 
         /** DB 저장 및 리턴 */

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarOptionServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarOptionServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarOptionDto;
 import com.yangsunkue.suncar.entity.car.CarOption;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarOptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 public class CarOptionServiceImpl implements CarOptionService {
 
     private final CarOptionRepository carOptionRepository;
+    private final CarMapper carMapper;
 
     @Override
     @Transactional
@@ -29,7 +31,7 @@ public class CarOptionServiceImpl implements CarOptionService {
 
         /** 모든 DTO를 엔티티로 변환 */
         List<CarOption> carOptions = dtos.stream()
-                .map(CarOptionDto::toEntity)
+                .map(carMapper::fromOptionDto)
                 .collect(Collectors.toList());
 
         /** DB 저장 및 리턴 */

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarOwnershipChangeServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarOwnershipChangeServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarOwnershipChangeDto;
 import com.yangsunkue.suncar.entity.car.CarOwnershipChange;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarOwnershipChangeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 public class CarOwnershipChangeServiceImpl implements CarOwnershipChangeService {
 
     private final CarOwnershipChangeRepository carOwnershipChangeRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 번호/소유자 변경이력 정보를 다수 생성합니다.
@@ -29,7 +31,7 @@ public class CarOwnershipChangeServiceImpl implements CarOwnershipChangeService 
 
         /** 모든 DTO를 엔티티로 변환 */
         List<CarOwnershipChange> carOwnershipChanges = dtos.stream()
-                .map(CarOwnershipChangeDto::toEntity)
+                .map(carMapper::fromOwnershipChangeDto)
                 .collect(Collectors.toList());
 
         /** DB에 저장 후 리턴 */

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarDto;
 import com.yangsunkue.suncar.entity.car.Car;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CarServiceImpl implements CarService {
 
     private final CarRepository carRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 정보를 생성합니다.
@@ -23,7 +25,7 @@ public class CarServiceImpl implements CarService {
     @Override
     @Transactional
     public Car createCar(CarDto dto) {
-        Car car = CarDto.toEntity(dto);
+        Car car = carMapper.fromCarDto(dto);
         Car saved = carRepository.save(car);
 
         return saved;

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarUsageServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarUsageServiceImpl.java
@@ -3,6 +3,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarUsageDto;
 import com.yangsunkue.suncar.entity.car.CarUsage;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarUsageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import java.util.stream.Collectors;
 public class CarUsageServiceImpl implements CarUsageService {
 
     private final CarUsageRepository carUsageRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 사용이력 정보를 다수 생성합니다.
@@ -30,7 +32,7 @@ public class CarUsageServiceImpl implements CarUsageService {
 
         /** 모든 DTO를 엔티티로 변환 */
         List<CarUsage> carUsages = dtos.stream()
-                .map(CarUsageDto::toEntity)
+                .map(carMapper::fromUsageDto)
                 .collect(Collectors.toList());
 
         /** DB에 저장 후 리턴 */

--- a/src/main/java/com/yangsunkue/suncar/service/car/ModelServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/ModelServiceImpl.java
@@ -2,6 +2,7 @@ package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.ModelDto;
 import com.yangsunkue.suncar.entity.car.Model;
+import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.ModelRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,12 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ModelServiceImpl {
 
     private final ModelRepository modelRepository;
+    private final CarMapper carMapper;
 
     /**
      * 차량 모델/브랜드 정보를 생성합니다.
      */
     public Model createModel(ModelDto dto) {
-        Model model = ModelDto.toEntity(dto);
+        Model model = carMapper.fromModelDto(dto);
         Model saved = modelRepository.save(model);
         return saved;
     }

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementService.java
@@ -1,6 +1,6 @@
 package com.yangsunkue.suncar.service.facade;
 
-import com.yangsunkue.suncar.dto.car.CarListResponseDto;
+import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarManagementServiceImpl.java
@@ -1,7 +1,7 @@
 package com.yangsunkue.suncar.service.facade;
 
 import com.yangsunkue.suncar.common.enums.BrandName;
-import com.yangsunkue.suncar.dto.car.CarListResponseDto;
+import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
 import com.yangsunkue.suncar.repository.car.CarListingRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/yangsunkue/suncar/service/user/UserServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/user/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.yangsunkue.suncar.dto.user.response.UserProfileResponseDto;
 import com.yangsunkue.suncar.dto.user.request.UserProfileUpdateRequestDto;
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.exception.NotFoundException;
+import com.yangsunkue.suncar.mapper.UserMapper;
 import com.yangsunkue.suncar.repository.user.UserRepository;
 import com.yangsunkue.suncar.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService{
 
     private final UserRepository userRepository;
+    private final UserMapper userMapper;
 
     /**
      * 현재 사용자 정보를 수정합니다.
@@ -34,7 +36,7 @@ public class UserServiceImpl implements UserService{
         currentUser.patch(dto);
 
         // dto 변환 및 리턴
-        UserProfileResponseDto responseDto = UserProfileResponseDto.fromUser(currentUser);
-        return responseDto;
+        UserProfileResponseDto profileDto = userMapper.toUserProfileResponseDto(currentUser);
+        return profileDto;
     }
 }


### PR DESCRIPTION
User 및 Car관련 모든 DTO <-> 엔티티 변환을 위한 매퍼 클래스 작성
변환 로직 전부 매퍼 클래스 메서드로 변경 완료

# PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 개발 환경 관련 설정
- [ ] 내부 문서 추가/수정
- [ ] 빌드 관련 코드 수정
- [ ] 파일 및 폴더명 수정
- [ ] 파일 삭제


## 이슈 번호
#20 

## 설명
- 각 dto 마다 toEntity, toDto 와 비슷한 DTO <-> 엔티티 변환용 팩토리 메서드가 필요했음.
- 하지만 단순 변환용 로직인데 지나치게 중복적이라고 판단
- 이러한 보일러 플레이트 코드를 줄이기 위해 매퍼 클래스를 도입하기로 함.

## 작업한 내용
- User엔티티 매퍼 클래스 작성
- 차량 관련 모든 엔티티 통합 매퍼 클래스 작성
- 기존 변환용 정적 팩토리 메서드들을, 전부 매퍼 메서드로 대체
- 기존 팩토리 메서드들 전부 삭제

## 비고
