### PR TITLE
Refactor: 차량 관련 facade 인터페이스 세분화 (LSP, ISP 원칙)

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
@@ -6,12 +6,11 @@ import com.yangsunkue.suncar.dto.car.request.RegisterCarDummyRequestDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
 import com.yangsunkue.suncar.security.CustomUserDetails;
-import com.yangsunkue.suncar.service.facade.CarFacadeService;
+import com.yangsunkue.suncar.service.facade.CarFacadeDummyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,8 +29,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CarController {
 
-    @Qualifier("CarFacadeServiceDummyImpl")
-    private final CarFacadeService carFacadeService;
+    /**
+     * 더미 데이터 입력용 구현체
+     *
+     * TODO
+     * 카히스토리 API 및 S3 도입 후, CarFacadeService 로 교체
+     */
+    private final CarFacadeDummyService carFacadeDummyService;
 
     /**
      * 판매중인 차량 목록을 조회합니다.
@@ -39,7 +43,7 @@ public class CarController {
     @GetMapping("")
     @Operation(summary = "판매 차량 목록 조회")
     public ResponseDto<List<CarListResponseDto>> getCarList() {
-        List<CarListResponseDto> carList = carFacadeService.getCarList();
+        List<CarListResponseDto> carList = carFacadeDummyService.getCarList();
         return ResponseDto.of(ResponseMessages.CAR_LIST_RETRIEVED, carList);
     }
 
@@ -81,7 +85,7 @@ public class CarController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody RegisterCarDummyRequestDto dto
     ) {
-        RegisterCarResponseDto registeredCar = carFacadeService.registerCar(dto, userDetails.getUserId());
+        RegisterCarResponseDto registeredCar = carFacadeDummyService.registerCar(dto, userDetails.getUserId());
         ResponseDto<RegisterCarResponseDto> response = ResponseDto.of(ResponseMessages.CAR_REGISTERED, registeredCar);
 
         /**

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeBaseService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeBaseService.java
@@ -1,0 +1,16 @@
+package com.yangsunkue.suncar.service.facade;
+
+import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
+
+import java.util.List;
+
+/**
+ * 차량 관련 Facade Base 서비스 입니다.
+ */
+public interface CarFacadeBaseService {
+
+    /**
+     * 판매중인 차량 목록을 조회합니다.
+     */
+    List<CarListResponseDto> getCarList();
+}

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyService.java
@@ -1,0 +1,16 @@
+package com.yangsunkue.suncar.service.facade;
+
+import com.yangsunkue.suncar.dto.car.request.RegisterCarDummyRequestDto;
+import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
+
+/**
+ * 차량 관련 Facade 서비스 입니다.
+ * - 더미 데이터 입력용 입니다.
+ */
+public interface CarFacadeDummyService extends CarFacadeBaseService {
+
+    /**
+     * 차량을 판매등록합니다. - 더미 데이터 입력을 위한 메서드 입니다.
+     */
+    RegisterCarResponseDto registerCar(RegisterCarDummyRequestDto dto, String userId);
+}

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyServiceImpl.java
@@ -16,9 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +28,7 @@ import java.util.List;
 @Profile("dev")
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class CarFacadeServiceDummyImpl implements CarFacadeService {
+public class CarFacadeDummyServiceImpl implements CarFacadeDummyService {
 
     private final CarDummyDataGenerator carDummyDataGenerator;
     private final CarMapper carMapper;
@@ -58,19 +56,6 @@ public class CarFacadeServiceDummyImpl implements CarFacadeService {
         return carList;
     }
 
-    /**
-     * 차량을 판매등록합니다.
-     */
-    @Override
-    @Transactional
-    public RegisterCarResponseDto registerCar(
-            MultipartFile mainImage,
-            List<MultipartFile> additionalImages,
-            String carNumber,
-            BigDecimal price
-    ) {
-        return RegisterCarResponseDto.builder().build();
-    }
 
     /**
      * 차량을 판매등록합니다.

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeService.java
@@ -1,9 +1,6 @@
 package com.yangsunkue.suncar.service.facade;
 
-import com.yangsunkue.suncar.dto.car.request.RegisterCarDummyRequestDto;
-import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
-import com.yangsunkue.suncar.security.CustomUserDetails;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
@@ -12,13 +9,7 @@ import java.util.List;
 /**
  * 차량 관련 Facade 서비스 입니다.
  */
-public interface CarFacadeService {
-
-    /**
-     * 판매중인 차량 목록을 조회합니다.
-     */
-    List<CarListResponseDto> getCarList();
-
+public interface CarFacadeService extends CarFacadeBaseService {
 
     /**
      * 차량을 판매등록합니다.
@@ -29,9 +20,4 @@ public interface CarFacadeService {
             String carNumber,
             BigDecimal price
     );
-
-    /**
-     * 차량을 판매등록합니다. - 더미 데이터 입력을 위한 오버로딩 메서드 입니다.
-     */
-    RegisterCarResponseDto registerCar(RegisterCarDummyRequestDto dto, String userId);
 }

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeServiceImpl.java
@@ -1,12 +1,7 @@
 package com.yangsunkue.suncar.service.facade;
 
-import com.yangsunkue.suncar.common.constant.ErrorMessages;
-import com.yangsunkue.suncar.dto.car.request.RegisterCarDummyRequestDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
-import com.yangsunkue.suncar.exception.DummyDataNotSupportedException;
-import com.yangsunkue.suncar.repository.car.*;
-import com.yangsunkue.suncar.repository.user.UserRepository;
 import com.yangsunkue.suncar.service.car.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -66,14 +61,5 @@ public class CarFacadeServiceImpl implements CarFacadeService {
          */
 
         return RegisterCarResponseDto.builder().build();
-    }
-
-    /**
-     * 차량을 판매등록합니다. - 더미 데이터 입력을 위한 오버로딩 메서드 입니다.
-     */
-    @Override
-    @Transactional
-    public RegisterCarResponseDto registerCar(RegisterCarDummyRequestDto dto, String userId) {
-        throw new DummyDataNotSupportedException(ErrorMessages.DUMMY_DATA_NOT_SUPPORTED);
     }
 }


### PR DESCRIPTION
## 이슈 번호
#27 

## 설명
- 기존 1개의 인터페이스로 만들어진 구현체는 서로를 대체할 수 없음 (LSP 위반)
- 또한 사용하지 않는 메서드를 구현하고 있음 (ISP 위반)
- 인터페이스를 필요에 따라 3개로 분리 (ISP 준수)
- 각 구현체가 다른 인터페이스를 갖게 하도록 함 (대체될 필요 없음, LSP 준수)

## 작업한 내용
- CarFacadeService 인터페이스 세분화 -> CarFacadeBaseService, CarFacadeService, CarFacadeDummyService
- 필요한 메서드만 구현할 수 있도록, 필요한 인터페이스만 상속받아 메서드 구현

## 비고
