### PR TITLE
Feat: 차량 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/common/constant/ErrorMessages.java
+++ b/src/main/java/com/yangsunkue/suncar/common/constant/ErrorMessages.java
@@ -16,5 +16,5 @@ public class ErrorMessages {
     public static final String DUPLICATE_MAIN_IMAGE = "이미 메인 이미지가 존재합니다.";
     public static final String IMAGE_NOT_PRIMARY = "메인 이미지 생성 요청에는 isPrimary가 true 여야 합니다.";
     public static final String PRIMARY_IMAGES_NOT_ALLOWED = "일반 이미지 생성 요청에는 isPrimary가 false 여야 합니다.";
-    public static final String DUMMY_DATA_NOT_SUPPORTED = "프로덕션 환경에서는 더미 데이터 생성이 지원되지 않습니다.";
+    public static final String CAR_LISTING_NOT_FOUND = "판매 등록된 차량 정보를 찾을 수 없습니다.";
 }

--- a/src/main/java/com/yangsunkue/suncar/common/constant/ResponseMessages.java
+++ b/src/main/java/com/yangsunkue/suncar/common/constant/ResponseMessages.java
@@ -19,4 +19,5 @@ public class ResponseMessages {
      */
     public static final String CAR_LIST_RETRIEVED = "차량 목록을 조회하였습니다.";
     public static final String CAR_REGISTERED = "차량을 판매등록하였습니다.";
+    public static final String CAR_DETAIL_RETRIEVED = "판매 차량 상세정보를 조회하였습니다.";
 }

--- a/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
@@ -3,6 +3,7 @@ package com.yangsunkue.suncar.controller.car;
 import com.yangsunkue.suncar.common.constant.ResponseMessages;
 import com.yangsunkue.suncar.dto.ResponseDto;
 import com.yangsunkue.suncar.dto.car.request.RegisterCarDummyRequestDto;
+import com.yangsunkue.suncar.dto.car.response.CarDetailResponseDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
 import com.yangsunkue.suncar.security.CustomUserDetails;
@@ -48,7 +49,7 @@ public class CarController {
     }
 
     /**
-     * 차량을 판매등록합니다.
+     * 차량을 판매등록합니다. - 배포용
      */
 //    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 //    @SecurityRequirement(name = "bearer-jwt")
@@ -88,28 +89,17 @@ public class CarController {
         RegisterCarResponseDto registeredCar = carFacadeDummyService.registerCar(dto, userDetails.getUserId());
         ResponseDto<RegisterCarResponseDto> response = ResponseDto.of(ResponseMessages.CAR_REGISTERED, registeredCar);
 
-        /**
-         * TODO
-         * 등록된 차량 상세조회 페이지 경로 리턴해주기
-         */
-        return ResponseEntity.created(URI.create("/cars"))
+        return ResponseEntity.created(URI.create("/cars/" + registeredCar.getListingId()))
                 .body(response);
     }
 
+    /**
+     * 판매 차량 상세정보를 조회합니다.
+     */
+    @GetMapping("/{listingId}")
+    @Operation(summary = "판매 차량 상세정보 조회")
+    public ResponseDto<CarDetailResponseDto> getCarDetail(@PathVariable Long listingId) {
+        CarDetailResponseDto carDetail = carFacadeDummyService.getCarDetail(listingId);
+        return ResponseDto.of(ResponseMessages.CAR_DETAIL_RETRIEVED, carDetail);
+    }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentDto.java
@@ -1,17 +1,18 @@
 package com.yangsunkue.suncar.dto.car;
 
-import com.yangsunkue.suncar.entity.car.Car;
-import com.yangsunkue.suncar.entity.car.CarAccident;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+@SuperBuilder
 @Getter
 public class CarAccidentDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long carId;
     private LocalDate accidentDate;
     private String accidentType;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentRepairDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentRepairDto.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.dto.car;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yangsunkue.suncar.entity.car.CarAccident;
 import com.yangsunkue.suncar.entity.car.CarAccidentRepair;
 import lombok.*;
@@ -12,6 +13,7 @@ import java.math.BigDecimal;
 @Getter
 public class CarAccidentRepairDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long accidentId;
     private String accidType;
     private String totalAmount;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentWithRepairsDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarAccidentWithRepairsDto.java
@@ -1,0 +1,20 @@
+package com.yangsunkue.suncar.dto.car;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+
+/**
+ * 기존 사고이력 Dto에 수리정보를 포함하기 위한 Dto 입니다.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+@Getter
+@Setter
+public class CarAccidentWithRepairsDto extends CarAccidentDto {
+
+    private List<CarAccidentRepairDto> repairs;
+}

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarDto.java
@@ -1,7 +1,5 @@
 package com.yangsunkue.suncar.dto.car;
 
-import com.yangsunkue.suncar.entity.car.Car;
-import com.yangsunkue.suncar.entity.car.Model;
 import lombok.*;
 
 

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarMileageDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarMileageDto.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.dto.car;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yangsunkue.suncar.entity.car.Car;
 import com.yangsunkue.suncar.entity.car.CarMileage;
 import lombok.*;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @Builder
 public class CarMileageDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long carId;
     private Integer distance;
     private String provider;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarOptionDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarOptionDto.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.dto.car;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yangsunkue.suncar.common.enums.OptionInstallStatus;
 import com.yangsunkue.suncar.entity.car.Car;
 import com.yangsunkue.suncar.entity.car.CarOption;
@@ -11,6 +12,7 @@ import lombok.*;
 @Getter
 public class CarOptionDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long carId;
     private String optionName;
     private OptionInstallStatus installStatus;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarOwnershipChangeDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarOwnershipChangeDto.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.dto.car;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yangsunkue.suncar.entity.car.Car;
 import com.yangsunkue.suncar.entity.car.CarOwnershipChange;
 import lombok.*;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @Getter
 public class CarOwnershipChangeDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long carId;
     private LocalDate changeDate;
     private String changeType;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarUsageDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarUsageDto.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.dto.car;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yangsunkue.suncar.entity.car.Car;
 import com.yangsunkue.suncar.entity.car.CarUsage;
 import lombok.*;
@@ -10,6 +11,7 @@ import lombok.*;
 @Getter
 public class CarUsageDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long carId;
     private String rentalHistory;
     private String businessHistory;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/response/CarDetailResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/response/CarDetailResponseDto.java
@@ -1,0 +1,66 @@
+package com.yangsunkue.suncar.dto.car.response;
+
+import com.yangsunkue.suncar.common.enums.CarListingStatus;
+import com.yangsunkue.suncar.dto.car.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+@Setter
+public class CarDetailResponseDto {
+
+    /** CarListing */
+    private Long id;
+    private BigDecimal price;
+    private String description;
+    private CarListingStatus status;
+
+    /** User */
+    private Long sellerId;
+    private String sellerUserName;
+
+    /** Car */
+    private Long carId;
+    private String carName;
+    private String carNumber;
+    private String displacement;
+    private String fuelType;
+    private Integer year;
+    private Integer month;
+    private String bodyShape;
+    private String modelType;
+    private LocalDate firstInsuranceDate;
+    private String identificationNumber;
+    private BigDecimal minPrice;
+    private BigDecimal maxPrice;
+
+    /** Model */
+    private String brandName;
+    private String modelName;
+    private Boolean isForeign;
+
+    /** CarListingImage */
+    private String mainImageUrl;
+    private List<String> additionalImageUrls;
+
+    /**
+     * CarAccident
+     * CarMileage
+     * CarOption
+     * CarOwnershipChange
+     * CarUsage
+     */
+    private List<CarAccidentWithRepairsDto> accidents;
+    private List<CarMileageDto> mileages;
+    private List<CarOptionDto> options;
+    private List<CarOwnershipChangeDto> ownershipChanges;
+    private CarUsageDto usage;
+
+
+}

--- a/src/main/java/com/yangsunkue/suncar/dto/repository/CarDetailFetchResult.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/repository/CarDetailFetchResult.java
@@ -1,0 +1,22 @@
+package com.yangsunkue.suncar.dto.repository;
+
+import com.yangsunkue.suncar.entity.car.*;
+
+import java.util.List;
+import java.util.Map;
+
+/** 차량 상세조회 결과 래핑 레코드 입니다.
+ * CarListingRepositoryCustomImpl - getCarDetailById(Long listingId)
+ */
+public record CarDetailFetchResult (
+        CarListing carListing,
+        List<CarListingImage> images,
+        List<CarAccident> accidents,
+        Map<Long, List<CarAccidentRepair>> repairsByAccidentId,
+        List<CarMileage> mileages,
+        List<CarOption> options,
+        List<CarOwnershipChange> ownershipChanges,
+        CarUsage usage
+) {
+
+}

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarAccidentRepair.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarAccidentRepair.java
@@ -2,10 +2,7 @@ package com.yangsunkue.suncar.entity.car;
 
 import com.yangsunkue.suncar.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 import java.math.BigDecimal;
@@ -19,6 +16,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class CarAccidentRepair extends BaseEntity {
 
     @Id

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarListingImage.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarListingImage.java
@@ -2,10 +2,7 @@ package com.yangsunkue.suncar.entity.car;
 
 import com.yangsunkue.suncar.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 /**
@@ -17,6 +14,7 @@ import org.hibernate.annotations.SQLDelete;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class CarListingImage extends BaseEntity {
 
     @Id

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarMileage.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarMileage.java
@@ -2,10 +2,7 @@ package com.yangsunkue.suncar.entity.car;
 
 import com.yangsunkue.suncar.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
@@ -19,6 +16,7 @@ import java.time.LocalDate;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class CarMileage extends BaseEntity {
 
     @Id

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarOption.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarOption.java
@@ -3,10 +3,7 @@ package com.yangsunkue.suncar.entity.car;
 import com.yangsunkue.suncar.common.enums.OptionInstallStatus;
 import com.yangsunkue.suncar.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 /**
@@ -18,6 +15,7 @@ import org.hibernate.annotations.SQLDelete;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class CarOption extends BaseEntity {
 
     @Id

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarOwnershipChange.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarOwnershipChange.java
@@ -1,10 +1,7 @@
 package com.yangsunkue.suncar.entity.car;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
@@ -18,6 +15,7 @@ import java.time.LocalDate;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class CarOwnershipChange {
 
     @Id

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarUsage.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarUsage.java
@@ -2,10 +2,7 @@ package com.yangsunkue.suncar.entity.car;
 
 import com.yangsunkue.suncar.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 /**
@@ -17,6 +14,7 @@ import org.hibernate.annotations.SQLDelete;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class CarUsage extends BaseEntity {
 
     @Id

--- a/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
+++ b/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
@@ -1,10 +1,15 @@
 package com.yangsunkue.suncar.mapper;
 
 import com.yangsunkue.suncar.dto.car.*;
+import com.yangsunkue.suncar.dto.car.response.CarDetailResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
 import com.yangsunkue.suncar.entity.car.*;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 차량 관련 모든 엔티티 매퍼 인터페이스 입니다.
@@ -44,6 +49,8 @@ public interface CarMapper {
     CarUsage fromUsageDto(CarUsageDto dto);
     Model fromModelDto(ModelDto dto);
 
+
+
     /** to Dto */
     @Mapping(source = "carListing.id", target = "listingId")
     @Mapping(source = "carListing.price", target = "price")
@@ -55,4 +62,72 @@ public interface CarMapper {
             Car car,
             Model model
     );
+
+    @Mapping(source = "car.id", target = "carId")
+    @Mapping(source = "car.carName", target = "carName")
+    @Mapping(source = "car.carNumber", target = "carNumber")
+    @Mapping(source = "car.displacement", target = "displacement")
+    @Mapping(source = "car.fuelType", target = "fuelType")
+    @Mapping(source = "car.year", target = "year")
+    @Mapping(source = "car.month", target = "month")
+    @Mapping(source = "car.bodyShape", target = "bodyShape")
+    @Mapping(source = "car.modelType", target = "modelType")
+    @Mapping(source = "car.firstInsuranceDate", target = "firstInsuranceDate")
+    @Mapping(source = "car.identificationNumber", target = "identificationNumber")
+    @Mapping(source = "car.minPrice", target = "minPrice")
+    @Mapping(source = "car.maxPrice", target = "maxPrice")
+    @Mapping(source = "car.model.brandName", target = "brandName")
+    @Mapping(source = "car.model.modelName", target = "modelName")
+    @Mapping(source = "car.model.isForeign", target = "isForeign")
+    @Mapping(source = "user.id", target = "sellerId")
+    @Mapping(source = "user.username", target = "sellerUserName")
+    @Mapping(target = "mainImageUrl", ignore = true)
+    @Mapping(target = "additionalImageUrls", ignore = true)
+    @Mapping(target = "accidents", ignore = true)
+    @Mapping(target = "mileages", ignore = true)
+    @Mapping(target = "options", ignore = true)
+    @Mapping(target = "ownershipChanges", ignore = true)
+    @Mapping(target = "usage", ignore = true)
+    CarDetailResponseDto toCarDetailResponseDto(CarListing carListing);
+
+    /** 사고이력, 사고당 수리이력을 합쳐 Dto로 변환합니다. */
+    default List<CarAccidentWithRepairsDto> toCarAccidentWithRepairsDtos(
+            List<CarAccident> accidents,
+            Map<Long, List<CarAccidentRepair>> repairsByAccidentId
+    ) {
+        if (accidents == null) {
+            return null;
+        }
+
+        return accidents.stream()
+                .map(accident -> {
+                    CarAccidentWithRepairsDto dto = toCarAccidentWithRepairsDto(accident);
+
+                    // 사고별 수리이력 추가
+                    List<CarAccidentRepair> repairs = repairsByAccidentId.getOrDefault(accident.getId(), List.of());
+                    dto.setRepairs(toCarAccidentRepairDtos(repairs));
+
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+    @Mapping(target = "repairs", ignore = true)
+    CarAccidentWithRepairsDto toCarAccidentWithRepairsDto(CarAccident accident);
+    List<CarAccidentRepairDto> toCarAccidentRepairDtos(List<CarAccidentRepair> repairs);
+
+    List<CarMileageDto> toCarMileageDtos(List<CarMileage> mileages);
+
+    @Mapping(target = "carId", ignore = true)
+    CarMileageDto toCarMileageDto(CarMileage mileage);
+
+    List<CarOptionDto> toCarOptionDtos(List<CarOption> options);
+    @Mapping(target = "carId", ignore = true)
+    CarOptionDto toCarOptionDto(CarOption option);
+
+    List<CarOwnershipChangeDto> toCarOwnershipChangeDtos(List<CarOwnershipChange> ownershipChanges);
+    @Mapping(target = "carId", ignore = true)
+    CarOwnershipChangeDto toCarOwnershipChangeDto(CarOwnershipChange ownershipChange);
+
+    @Mapping(target = "carId", ignore = true)
+    CarUsageDto toCarUsageDto(CarUsage usage);
 }

--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
@@ -1,12 +1,17 @@
 package com.yangsunkue.suncar.repository.car;
 
+import com.yangsunkue.suncar.dto.car.response.CarDetailResponseDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
+import com.yangsunkue.suncar.dto.repository.CarDetailFetchResult;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * CarListing Custom Repository 입니다.
  */
 public interface CarListingRepositoryCustom {
     List<CarListResponseDto> getCarList();
+
+    Optional<CarDetailFetchResult> getCarDetailById(Long listingId);
 }

--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImpl.java
@@ -4,15 +4,15 @@ import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
+import com.yangsunkue.suncar.dto.repository.CarDetailFetchResult;
 import com.yangsunkue.suncar.entity.car.*;
+import com.yangsunkue.suncar.entity.user.QUser;
 import com.yangsunkue.suncar.repository.support.Querydsl4RepositorySupport;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * CarListing Custom Repository 구현체입니다.
@@ -119,6 +119,108 @@ public class CarListingRepositoryCustomImpl extends Querydsl4RepositorySupport i
 
         /** 만들어진 dto 리스트를 반환 */
         return new ArrayList<>(dtoMap.values());
+    }
+
+    /**
+     * 차량 상세정보를 조회합니다.
+     */
+    @Override
+    public Optional<CarDetailFetchResult> getCarDetailById(Long listingId) {
+
+        QUser user = QUser.user;
+        QCar car = QCar.car;
+        QCarAccident carAccident = QCarAccident.carAccident;
+        QCarAccidentRepair carAccidentRepair = QCarAccidentRepair.carAccidentRepair;
+        QCarListing carListing = QCarListing.carListing;
+        QCarListingImage carListingImage = QCarListingImage.carListingImage;
+        QCarMileage carMileage = QCarMileage.carMileage;
+        QCarOption carOption = QCarOption.carOption;
+        QCarOwnershipChange carOwnershipChange = QCarOwnershipChange.carOwnershipChange;
+        QCarUsage carUsage = QCarUsage.carUsage;
+        QModel model = QModel.model;
+
+        /** 1. 기본 차량 정보 조회 (CarListing, Car, Model, User) */
+        CarListing result = getQueryFactory()
+                .selectFrom(carListing)
+                .join(carListing.car, car).fetchJoin()
+                .join(car.model, model).fetchJoin()
+                .join(carListing.user, user).fetchJoin()
+                .where(carListing.id.eq(listingId))
+                .fetchOne();
+
+        if (result == null) {
+            return Optional.empty();
+        }
+        Long carId = result.getCar().getId();
+
+
+        /** 2. 모든 이미지 정보 조회 */
+        List<CarListingImage> images = getQueryFactory()
+                .selectFrom(carListingImage)
+                .where(carListingImage.carListing.id.eq(listingId))
+                .fetch();
+
+        /** 3. 사고 정보와 수리 정보 조회 */
+        // 사고이력 전부 가져오기
+        List<CarAccident> accidents = getQueryFactory()
+                .selectFrom(carAccident)
+                .where(carAccident.car.id.eq(carId))
+                .fetch();
+
+        // 사고이력 id 리스트 생성
+        List<Long> accidentIds = accidents.stream()
+                .map(CarAccident::getId)
+                .collect(Collectors.toList());
+
+        // 사고이력들의 수리정보 전부 조회
+        List<CarAccidentRepair> repairs = accidentIds.isEmpty()
+                ? List.of()
+                : getQueryFactory()
+                    .selectFrom(carAccidentRepair)
+                    .where(carAccidentRepair.carAccident.id.in(accidentIds))
+                    .fetch();
+
+        // 수리정보를 사고이력 id 기준으로 그룹핑 리스트화
+        Map<Long, List<CarAccidentRepair>> repairsByAccidentId = repairs.stream()
+                .collect(Collectors.groupingBy(repair -> repair.getCarAccident().getId()));
+
+        /** 4. 주행거리 조회 */
+        List<CarMileage> mileages = getQueryFactory()
+                .selectFrom(carMileage)
+                .where(carMileage.car.id.eq(carId))
+                .orderBy(carMileage.recordDate.desc())
+                .fetch();
+
+        /** 5. 옵션/안전장치 조회 */
+        List<CarOption> options = getQueryFactory()
+                .selectFrom(carOption)
+                .where(carOption.car.id.eq(carId))
+                .fetch();
+
+        /** 6. 소유자/번호 변경이력 조회 */
+        List<CarOwnershipChange> ownershipChanges = getQueryFactory()
+                .selectFrom(carOwnershipChange)
+                .where(carOwnershipChange.car.id.eq(carId))
+                .orderBy(carOwnershipChange.changeDate.desc())
+                .fetch();
+
+        /** 7. 사용이력 조회 */
+        CarUsage usage = getQueryFactory()
+                .selectFrom(carUsage)
+                .where(carUsage.car.id.eq(carId))
+                .fetchFirst();
+
+        /** 결과 엔티티 리턴 */
+        return Optional.of(new CarDetailFetchResult(
+                result,
+                images,
+                accidents,
+                repairsByAccidentId,
+                mileages,
+                options,
+                ownershipChanges,
+                usage
+        ));
     }
 }
 

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeBaseService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeBaseService.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.service.facade;
 
+import com.yangsunkue.suncar.dto.car.response.CarDetailResponseDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 
 import java.util.List;
@@ -13,4 +14,9 @@ public interface CarFacadeBaseService {
      * 판매중인 차량 목록을 조회합니다.
      */
     List<CarListResponseDto> getCarList();
+
+    /**
+     * 판매 차량 상세정보를 조회합니다.
+     */
+    CarDetailResponseDto getCarDetail(Long listingId);
 }

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeServiceImpl.java
@@ -1,7 +1,14 @@
 package com.yangsunkue.suncar.service.facade;
 
+import com.yangsunkue.suncar.common.constant.ErrorMessages;
+import com.yangsunkue.suncar.dto.car.response.CarDetailResponseDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
+import com.yangsunkue.suncar.dto.repository.CarDetailFetchResult;
+import com.yangsunkue.suncar.entity.car.CarListingImage;
+import com.yangsunkue.suncar.exception.NotFoundException;
+import com.yangsunkue.suncar.mapper.CarMapper;
+import com.yangsunkue.suncar.repository.car.CarListingRepository;
 import com.yangsunkue.suncar.service.car.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -10,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -21,6 +29,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CarFacadeServiceImpl implements CarFacadeService {
 
+    private final CarMapper carMapper;
+    private final CarListingRepository carListingRepository;
     private final CarListingService carListingService;
 
     /**
@@ -30,6 +40,38 @@ public class CarFacadeServiceImpl implements CarFacadeService {
     public List<CarListResponseDto> getCarList() {
         List<CarListResponseDto> carList = carListingService.getCarList();
         return carList;
+    }
+
+    /**
+     * 판매 차량 상세정보를 조회합니다.
+     * QueryDSL을 사용하여 데이터를 가져온 후, 서비스에서 매퍼를 통해 DTO로 변환됩니다.
+     *
+     * @param listingId 차량 판매등록 ID
+     * @return
+     */
+    @Override
+    public CarDetailResponseDto getCarDetail(Long listingId) {
+
+        /** 차량 상세정보 엔티티들 조회 */
+        CarDetailFetchResult data = carListingRepository.getCarDetailById(listingId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
+
+        /** DTO로 변환 */
+        CarDetailResponseDto carDetail = carMapper.toCarDetailResponseDto(data.carListing());
+
+        Long carId = data.carListing().getCar().getId();
+
+        /** 나머지 데이터 매핑 */
+        processImages(data.images(), carDetail);
+        carDetail.setAccidents(carMapper.toCarAccidentWithRepairsDtos(data.accidents(), data.repairsByAccidentId()));
+        carDetail.setMileages(carMapper.toCarMileageDtos(data.mileages()));
+        carDetail.setOptions(carMapper.toCarOptionDtos(data.options()));
+        carDetail.setOwnershipChanges(carMapper.toCarOwnershipChangeDtos(data.ownershipChanges()));
+        if (data.usage() != null) {
+            carDetail.setUsage(carMapper.toCarUsageDto(data.usage()));
+        }
+
+        return carDetail;
     }
 
     /**
@@ -61,5 +103,26 @@ public class CarFacadeServiceImpl implements CarFacadeService {
          */
 
         return RegisterCarResponseDto.builder().build();
+    }
+
+    /**
+     * 이미지 데이터를 받아 메인/일반 이미지로 구분하여 dto에 담습니다.
+     */
+    private void processImages(List<CarListingImage> images, CarDetailResponseDto dto) {
+
+        String mainImageUrl = null;
+        List<String> additionalImageUrls = new ArrayList<>();
+
+        for (CarListingImage image : images) {
+            if (image.getIsPrimary()) {
+                mainImageUrl = image.getImageUrl();
+            }
+            else {
+                additionalImageUrls.add(image.getImageUrl());
+            }
+        }
+
+        dto.setMainImageUrl(mainImageUrl);
+        dto.setAdditionalImageUrls(additionalImageUrls);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,5 +19,5 @@ springdoc.swagger-ui.tags-sorter=alpha
 springdoc.swagger-ui.operations-sorter=alpha
 springdoc.packages-to-scan=com.yangsunkue.suncar.controller
 
-# ?? ???? ??
+# Run as a dev environment
 spring.profiles.active=dev


### PR DESCRIPTION
## 이슈 번호
- #29 

## 작업한 내용
- CarListing 엔티티를 시작으로 10개 엔티티를 조회하는 커스텀 쿼리 작성
- 쿼리 결과를 담는 래핑 클래스 작성
- 응답 DTO 작성 및 기존 DTO들 수정
- 매퍼 메서드 추가
- Facade 서비스 함수 작성

## 설명
- 핵심 엔티티 4개는 fetchJoin으로 단일 쿼리를 사용하여 N+1 문제 방지
- 나머지 관련 엔티티들은 쿼리를 분리하여 카테시안 곱 문제 방지
- 명확한 책임 분리 -> repository(데이터 조회), service(비즈니스 로직), mapper(변환)

## 비고
- 없음