### PR TITLE
Test: 인증, 유저 관련 서비스 예외 검증 테스트 코드 추가

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/dto/auth/request/SignUpRequestDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/auth/request/SignUpRequestDto.java
@@ -9,6 +9,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Setter
 @ToString
 @Builder
 public class SignUpRequestDto {

--- a/src/test/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImplTest.java
+++ b/src/test/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImplTest.java
@@ -110,7 +110,7 @@ class CarListingRepositoryCustomImplTest {
 
     @Test
     @DisplayName("판매중인 차량 목록 조회 테스트")
-    void getCarListTest() {
+    void getCarList() {
 
         // when
         List<CarListResponseDto> result = carListingRepository.getCarList();
@@ -129,7 +129,7 @@ class CarListingRepositoryCustomImplTest {
 
     @Test
     @DisplayName("판매중인 차량 목록 조회 시 N+1 문제 없이 한 번의 쿼리로 조회되는지 테스트")
-    void getCarListFetchedWithSingleQueryTest() {
+    void shouldFetchCarListWithSingleQuery() {
 
         // when
         carListingRepository.getCarList();
@@ -141,7 +141,7 @@ class CarListingRepositoryCustomImplTest {
 
     @Test
     @DisplayName("판매중인 차량이 없을 경우 빈 ArrayList 반환하는지 테스트")
-    void getCarListShouldReturnEmptyArrayListWhenNoDataExistsTest() {
+    void shouldReturnEmptyArrayListWhenNoDataExists() {
 
         // given
         em.createQuery("DELETE FROM CarListingImage").executeUpdate();
@@ -159,7 +159,7 @@ class CarListingRepositoryCustomImplTest {
 
     @Test
     @DisplayName("차량 상세정보 조회 테스트")
-    void getCarDetailByIdTest() {
+    void getCarDetailById() {
 
         // when
         Optional<CarDetailFetchResult> optionalResult = carListingRepository.getCarDetailById(testCarListing.getId());
@@ -178,7 +178,7 @@ class CarListingRepositoryCustomImplTest {
 
     @Test
     @DisplayName("차량 상세정보 조회 시 의도된 횟수(8회)만큼의 쿼리로 조회되는지 테스트")
-    void getCarDetailByIdShouldExecuteExpectedNumberOfQueriesTest() {
+    void ShouldExecuteExpectedNumberOfQueries() {
 
         // when
         carListingRepository.getCarDetailById(testCarListing.getId());
@@ -189,8 +189,8 @@ class CarListingRepositoryCustomImplTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 차량 상세정보 조회 시 빈 Optional 반환하는지 테스트")
-    void getCarDetailByIdNotFoundTest() {
+    @DisplayName("차량 상세정보 조회 시 데이터가 없을 경우 빈 Optional 반환하는지 테스트")
+    void shouldReturnEmptyOptionalWhenCarDetailDoesNotExist() {
 
         // when
         Optional<CarDetailFetchResult> result = carListingRepository.getCarDetailById(99999L);

--- a/src/test/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyServiceImplTest.java
+++ b/src/test/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyServiceImplTest.java
@@ -213,7 +213,7 @@ class CarFacadeDummyServiceImplTest {
 
     @Test
     @DisplayName("판매중인 차량 목록 조회 테스트")
-    void getCarListTest() {
+    void getCarList() {
 
         // given
         when(carListingService.getCarList()).thenReturn(testCarListResponseDtos);
@@ -233,13 +233,13 @@ class CarFacadeDummyServiceImplTest {
 
     @Test
     @DisplayName("판매 차량 상세정보 조회 테스트")
-    void getCarDetailTest() {
+    void getCarDetail() {
 
         // given
         Long listingId = testCarListing.getId();
 
         when(carListingRepository.getCarDetailById(listingId)).thenReturn(Optional.of(testCarDetailFetchResult));
-        when(carMapper.toCarDetailResponseDto(any(CarListing.class))).thenReturn(testCarDetailResponseDto);
+        when(carMapper.toCarDetailResponseDto(testCarListing)).thenReturn(testCarDetailResponseDto);
 
         // when
         CarDetailResponseDto result = carFacadeDummyServiceImpl.getCarDetail(listingId);
@@ -253,12 +253,12 @@ class CarFacadeDummyServiceImplTest {
                 .isEqualTo(testCarDetailResponseDto);
 
         verify(carListingRepository).getCarDetailById(listingId);
-        verify(carMapper).toCarDetailResponseDto(any(CarListing.class));
+        verify(carMapper).toCarDetailResponseDto(testCarListing);
     }
 
     @Test
     @DisplayName("판매 차량 상세정보 조회 시 데이터가 존재하지 않을 경우 Not Found 반환하는지 테스트")
-    void getCarDetailShouldReturnNotFoundWhenCarListingDoesNotExistTest() {
+    void shouldThrowNotFoundWhenCarListingDoesNotExist() {
 
         // given
         Long nonExistentListingId = 99999L;
@@ -277,7 +277,7 @@ class CarFacadeDummyServiceImplTest {
 
     @Test
     @DisplayName("차량 판매등록 테스트 - 더미 데이터")
-    void registerCarTest() {
+    void registerCar() {
 
         // given
         String userId = testUser.getUserId();
@@ -308,41 +308,41 @@ class CarFacadeDummyServiceImplTest {
 
         /** 메서드 모킹 */
         when(carDummyDataGenerator.generateModelDto()).thenReturn(modelDto);
-        when(modelService.createModel(any(ModelDto.class))).thenReturn(testModel);
+        when(modelService.createModel(modelDto)).thenReturn(testModel);
 
-        when(carDummyDataGenerator.generateCarDto(anyLong(), any(String.class))).thenReturn(carDto);
-        when(carService.createCar(any(CarDto.class))).thenReturn(testCar);
+        when(carDummyDataGenerator.generateCarDto(testModel.getId(), testCar.getCarNumber())).thenReturn(carDto);
+        when(carService.createCar(carDto)).thenReturn(testCar);
 
         when(userRepository.findByUserId(userId)).thenReturn(Optional.of(testUser));
 
-        when(carDummyDataGenerator.generateCarListingDto(anyLong(), anyLong(), any(BigDecimal.class))).thenReturn(carListingDto);
-        when(carListingService.createListing(any(CarListingDto.class))).thenReturn(testCarListing);
+        when(carDummyDataGenerator.generateCarListingDto(testCar.getId(), testUser.getId(), testCarListing.getPrice())).thenReturn(carListingDto);
+        when(carListingService.createListing(carListingDto)).thenReturn(testCarListing);
 
-        when(carDummyDataGenerator.generateCarAccidentDtos(anyLong())).thenReturn(accidentDtos);
-        when(carAccidentService.createAccidents(anyList())).thenReturn(accidents);
+        when(carDummyDataGenerator.generateCarAccidentDtos(testCar.getId())).thenReturn(accidentDtos);
+        when(carAccidentService.createAccidents(accidentDtos)).thenReturn(accidents);
 
         when(carDummyDataGenerator.generateCarAccidentRepairDtos(anyList())).thenReturn(accidentRepairDtos);
-        when(carAccidentRepairService.createAccidentRepairs(anyList())).thenReturn(accidentRepairs);
+        when(carAccidentRepairService.createAccidentRepairs(accidentRepairDtos)).thenReturn(accidentRepairs);
 
-        when(carDummyDataGenerator.generateCarMileageDtos(anyLong())).thenReturn(mileageDtos);
-        when(carMileageService.createMileages(anyList())).thenReturn(mileages);
+        when(carDummyDataGenerator.generateCarMileageDtos(testCar.getId())).thenReturn(mileageDtos);
+        when(carMileageService.createMileages(mileageDtos)).thenReturn(mileages);
 
-        when(carDummyDataGenerator.generateCarOwnershipChangeDtos(anyLong())).thenReturn(ownershipChangeDtos);
-        when(carOwnershipChangeService.createChanges(anyList())).thenReturn(ownershipChanges);
+        when(carDummyDataGenerator.generateCarOwnershipChangeDtos(testCar.getId())).thenReturn(ownershipChangeDtos);
+        when(carOwnershipChangeService.createChanges(ownershipChangeDtos)).thenReturn(ownershipChanges);
 
-        when(carDummyDataGenerator.generateCarUsageDto(anyLong())).thenReturn(usageDto);
-        when(carUsageService.createUsage(any(CarUsageDto.class))).thenReturn(usage);
+        when(carDummyDataGenerator.generateCarUsageDto(testCar.getId())).thenReturn(usageDto);
+        when(carUsageService.createUsage(usageDto)).thenReturn(usage);
 
-        when(carDummyDataGenerator.generateCarOptionDtos(anyLong())).thenReturn(optionDtos);
-        when(carOptionService.createOptions(anyList())).thenReturn(options);
+        when(carDummyDataGenerator.generateCarOptionDtos(testCar.getId())).thenReturn(optionDtos);
+        when(carOptionService.createOptions(optionDtos)).thenReturn(options);
 
-        when(carDummyDataGenerator.generateCarListingImageDtoFromMainImage(anyLong(), any(String.class))).thenReturn(mainImageDto);
-        when(carListingImageService.createMainImage(any(CarListingImageDto.class))).thenReturn(mainImage);
+        when(carDummyDataGenerator.generateCarListingImageDtoFromMainImage(eq(testCarListing.getId()), any(String.class))).thenReturn(mainImageDto);
+        when(carListingImageService.createMainImage(mainImageDto)).thenReturn(mainImage);
 
-        when(carDummyDataGenerator.generateCarListingDtosFromAdditionalImages(anyLong(), anyList())).thenReturn(additionalImageDtos);
-        when(carListingImageService.createImages(anyList())).thenReturn(additionalImages);
+        when(carDummyDataGenerator.generateCarListingDtosFromAdditionalImages(eq(testCarListing.getId()), anyList())).thenReturn(additionalImageDtos);
+        when(carListingImageService.createImages(additionalImageDtos)).thenReturn(additionalImages);
 
-        when(carMapper.toRegisterCarResponseDto(any(CarListing.class), any(Car.class), any(Model.class))).thenReturn(testRegisterCarResponseDto);
+        when(carMapper.toRegisterCarResponseDto(testCarListing, testCar, testModel)).thenReturn(testRegisterCarResponseDto);
 
         // when
         RegisterCarResponseDto result = carFacadeDummyServiceImpl.registerCar(testRegisterCarDummyRequestDto, userId);
@@ -360,7 +360,7 @@ class CarFacadeDummyServiceImplTest {
 
     @Test
     @DisplayName("차량 판매등록 시 판매자 정보가 존재하지 않을 경우 Not Found 반환하는지 테스트")
-    void registerCarShouldReturnNotFoundWhenSellerDoesNotExistTest() {
+    void shouldThrowNotFoundWhenSellerDoesNotExist() {
 
         // given
         String nonExistentSellerUserId = RandomUtils.createUuid(32);
@@ -371,7 +371,7 @@ class CarFacadeDummyServiceImplTest {
         when(carDummyDataGenerator.generateModelDto()).thenReturn(modelDto);
         when(modelService.createModel(modelDto)).thenReturn(testModel);
 
-        when(carDummyDataGenerator.generateCarDto(eq(testModel.getId()), any(String.class))).thenReturn(carDto);
+        when(carDummyDataGenerator.generateCarDto(testModel.getId(), testCar.getCarNumber())).thenReturn(carDto);
         when(carService.createCar(carDto)).thenReturn(testCar);
 
         NotFoundException exception = assertThrows(NotFoundException.class,
@@ -383,7 +383,7 @@ class CarFacadeDummyServiceImplTest {
         verify(carDummyDataGenerator).generateModelDto();
         verify(modelService).createModel(modelDto);
 
-        verify(carDummyDataGenerator).generateCarDto(eq(testModel.getId()), any(String.class));
+        verify(carDummyDataGenerator).generateCarDto(testModel.getId(), testCar.getCarNumber());
         verify(carService).createCar(carDto);
 
         verify(userRepository).findByUserId(nonExistentSellerUserId);

--- a/src/test/java/com/yangsunkue/suncar/service/user/UserServiceImplTest.java
+++ b/src/test/java/com/yangsunkue/suncar/service/user/UserServiceImplTest.java
@@ -1,11 +1,14 @@
 package com.yangsunkue.suncar.service.user;
 
+import com.yangsunkue.suncar.common.constant.ErrorMessages;
 import com.yangsunkue.suncar.dto.user.request.UserProfileUpdateRequestDto;
 import com.yangsunkue.suncar.dto.user.response.UserProfileResponseDto;
 import com.yangsunkue.suncar.entity.user.User;
+import com.yangsunkue.suncar.exception.NotFoundException;
 import com.yangsunkue.suncar.mapper.UserMapper;
 import com.yangsunkue.suncar.repository.user.UserRepository;
 import com.yangsunkue.suncar.security.CustomUserDetails;
+import com.yangsunkue.suncar.util.RandomUtils;
 import com.yangsunkue.suncar.util.factory.TestUserFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +22,7 @@ import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -64,20 +68,42 @@ class UserServiceImplTest {
     void updateCurrentUserProfile() {
 
         // given
-        when(userRepository.findByUserId(any(String.class))).thenReturn(Optional.of(testUser));
         when(testUserDetails.getUserId()).thenReturn(testUser.getUserId());
-        when(userMapper.toUserProfileResponseDto(any(User.class))).thenReturn(testUserProfileResponseDto);
+        when(userRepository.findByUserId(testUserDetails.getUserId())).thenReturn(Optional.of(testUser));
+        when(userMapper.toUserProfileResponseDto(testUser)).thenReturn(testUserProfileResponseDto);
 
         // when
         UserProfileResponseDto result = userServiceImpl.updateCurrentUserProfile(testUserDetails, testUserProfileUpdateRequestDto);
 
         // then
-        verify(userRepository).findByUserId(any(String.class));
-        verify(userMapper).toUserProfileResponseDto(testUser);
-
         assertThat(result.getUserId()).isEqualTo(testUser.getUserId());
         assertThat(result)
                 .usingRecursiveComparison()
                 .isEqualTo(testUserProfileResponseDto);
+
+        verify(userRepository).findByUserId(testUserDetails.getUserId());
+        verify(userMapper).toUserProfileResponseDto(testUser);
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 시 존재하지 않는 유저일 경우 Not Found 반환하는지 테스트")
+    void shouldThrowNotFoundWhenUserDoesNotExist() {
+
+        // given
+        String nonExistentUserId = RandomUtils.createUuid(32);
+        when(testUserDetails.getUserId()).thenReturn(nonExistentUserId);
+        when(userRepository.findByUserId(testUserDetails.getUserId())).thenReturn(Optional.empty());
+
+        // when
+        NotFoundException exception = assertThrows(NotFoundException.class,
+                () -> userServiceImpl.updateCurrentUserProfile(
+                        testUserDetails,
+                        testUserProfileUpdateRequestDto
+                ));
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo(ErrorMessages.USER_NOT_FOUND);
+        verify(userRepository).findByUserId(nonExistentUserId);
+        verify(userMapper, never()).toUserProfileResponseDto(any(User.class));
     }
 }


### PR DESCRIPTION
## 이슈 번호
- #40 

## 작업한 내용
인증, 유저 관련 서비스 예외 검증 테스트 코드 추가
- 단위 테스트
- NotFound, BadCredentials, DuplicateResource 등 예외를 적절히 반환하는지 테스트하는 메서드 추가

테스트 코드 소규모 리팩토링
- 테스트 코드 인자를 명확히 수정 ( any -> 특정 객체 )
- 지나치게 길었던 테스트 메서드명 간소화

## 설명
- 명시적 예외 처리에 대한 흐름을 테스트하는 단위 테스트 코드 추가
- 일관성, 가독성을 위해 모든 테스트 코드 소규모 리팩토링

## 비고
- 없음