### PR TITLE
Feat: 판매 차량 수정/삭제 기능 추가

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/common/constant/ErrorMessages.java
+++ b/src/main/java/com/yangsunkue/suncar/common/constant/ErrorMessages.java
@@ -20,4 +20,5 @@ public class ErrorMessages {
     public static final String IMAGE_NOT_PRIMARY = "메인 이미지 생성 요청에는 isPrimary가 true 여야 합니다.";
     public static final String PRIMARY_IMAGES_NOT_ALLOWED = "일반 이미지 생성 요청에는 isPrimary가 false 여야 합니다.";
     public static final String CAR_LISTING_NOT_FOUND = "판매 등록된 차량 정보를 찾을 수 없습니다.";
+    public static final String NOT_OWNER_OF_CAR_LISTING = "본인의 차량이 아닙니다.";
 }

--- a/src/main/java/com/yangsunkue/suncar/common/constant/ResponseMessages.java
+++ b/src/main/java/com/yangsunkue/suncar/common/constant/ResponseMessages.java
@@ -21,6 +21,8 @@ public class ResponseMessages {
      * Car 관련 응답 메시지
      */
     public static final String CAR_LIST_RETRIEVED = "차량 목록을 조회하였습니다.";
-    public static final String CAR_REGISTERED = "차량을 판매등록하였습니다.";
     public static final String CAR_DETAIL_RETRIEVED = "판매 차량 상세정보를 조회하였습니다.";
+    public static final String CAR_REGISTERED = "차량을 판매등록하였습니다.";
+    public static final String CAR_DETAIL_UPDATED = "판매 차량 상세정보를 수정하였습니다.";
+    public static final String CAR_LISTING_DELETED = "판매 차량을 삭제하였습니다.";
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/ResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/ResponseDto.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,7 @@ import lombok.Getter;
 public class ResponseDto<T> {
 
     private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private T data;
 
     // 데이터가 없는 경우 -> 메시지만 리턴

--- a/src/main/java/com/yangsunkue/suncar/dto/car/CarListingDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/CarListingDto.java
@@ -2,13 +2,14 @@ package com.yangsunkue.suncar.dto.car;
 
 import com.yangsunkue.suncar.common.enums.CarListingStatus;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Builder
+@SuperBuilder
 public class CarListingDto {
 
     private Long carId;

--- a/src/main/java/com/yangsunkue/suncar/dto/car/request/UpdateCarListingRequestDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/request/UpdateCarListingRequestDto.java
@@ -1,0 +1,17 @@
+package com.yangsunkue.suncar.dto.car.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UpdateCarListingRequestDto {
+
+    private BigDecimal price;
+    private String description;
+}

--- a/src/main/java/com/yangsunkue/suncar/dto/car/response/UpdateCarListingResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/response/UpdateCarListingResponseDto.java
@@ -1,0 +1,17 @@
+package com.yangsunkue.suncar.dto.car.response;
+
+import com.yangsunkue.suncar.dto.car.CarListingDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+@Setter
+public class UpdateCarListingResponseDto extends CarListingDto {
+
+    private Long id;
+}

--- a/src/main/java/com/yangsunkue/suncar/entity/BaseEntity.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/BaseEntity.java
@@ -41,7 +41,7 @@ public abstract class BaseEntity {
     /**
      * Soft delete : 삭제를 위한 메서드
      */
-    public void delete() {
+    public void softDelete() {
         this.isDeleted = true;
     }
 

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarListing.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarListing.java
@@ -1,6 +1,7 @@
 package com.yangsunkue.suncar.entity.car;
 
 import com.yangsunkue.suncar.common.enums.CarListingStatus;
+import com.yangsunkue.suncar.dto.car.request.UpdateCarListingRequestDto;
 import com.yangsunkue.suncar.entity.BaseEntity;
 import com.yangsunkue.suncar.entity.user.User;
 import jakarta.persistence.*;
@@ -45,4 +46,15 @@ public class CarListing extends BaseEntity {
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     private CarListingStatus status;
+
+    public void patch(UpdateCarListingRequestDto dto) {
+
+        /** 가격이 음수 또는 0이 아니어야 함 */
+        if (dto.getPrice() != null && (dto.getPrice().compareTo(BigDecimal.ZERO) > 0)) {
+            this.price = dto.getPrice();
+        }
+        if (dto.getDescription() != null && !dto.getDescription().isEmpty()) {
+            this.description = dto.getDescription();
+        }
+    }
 }

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarOwnershipChange.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarOwnershipChange.java
@@ -1,5 +1,6 @@
 package com.yangsunkue.suncar.entity.car;
 
+import com.yangsunkue.suncar.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
@@ -16,7 +17,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(toBuilder = true)
 @Getter
-public class CarOwnershipChange {
+public class CarOwnershipChange extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/yangsunkue/suncar/exception/ForbiddenException.java
+++ b/src/main/java/com/yangsunkue/suncar/exception/ForbiddenException.java
@@ -1,0 +1,16 @@
+package com.yangsunkue.suncar.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends BaseException {
+
+    /**
+     * 403 Forbidden
+     */
+    public ForbiddenException(String message) {
+        super(
+                message,
+                HttpStatus.FORBIDDEN
+        );
+    }
+}

--- a/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
+++ b/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
@@ -3,6 +3,7 @@ package com.yangsunkue.suncar.mapper;
 import com.yangsunkue.suncar.dto.car.*;
 import com.yangsunkue.suncar.dto.car.response.CarDetailResponseDto;
 import com.yangsunkue.suncar.dto.car.response.RegisterCarResponseDto;
+import com.yangsunkue.suncar.dto.car.response.UpdateCarListingResponseDto;
 import com.yangsunkue.suncar.entity.car.*;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -130,4 +131,8 @@ public interface CarMapper {
 
     @Mapping(target = "carId", ignore = true)
     CarUsageDto toCarUsageDto(CarUsage usage);
+
+    @Mapping(source = "car.id", target = "carId")
+    @Mapping(source = "user.id", target = "sellerId")
+    UpdateCarListingResponseDto toUpdateCarListingResponseDto(CarListing carListing);
 }

--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
@@ -11,7 +11,19 @@ import java.util.Optional;
  */
 public interface CarListingRepositoryCustom {
 
+    /**
+     * 모든 판매중인 자동차 정보를 찾습니다.
+     */
     List<CarListResponseDto> getCarList();
 
+    /**
+     * 차량 상세정보를 조회합니다.
+     */
     Optional<CarDetailFetchResult> getCarDetailById(Long listingId);
+
+    /**
+     * 판매중인 차량을 soft delete 방식으로 삭제합니다.
+     * CarListing 엔티티를 시작으로, 연관된 모든 엔티티를 함께 삭제합니다.
+     */
+    void softDeleteCarListingWithRelatedEntities(Long listingId);
 }

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingService.java
@@ -1,7 +1,9 @@
 package com.yangsunkue.suncar.service.car;
 
 import com.yangsunkue.suncar.dto.car.CarListingDto;
+import com.yangsunkue.suncar.dto.car.request.UpdateCarListingRequestDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
+import com.yangsunkue.suncar.dto.car.response.UpdateCarListingResponseDto;
 import com.yangsunkue.suncar.entity.car.CarListing;
 
 import java.util.List;
@@ -20,4 +22,16 @@ public interface CarListingService {
      * 차량 판매등록 정보를 생성합니다.
      */
     CarListing createListing(CarListingDto dto);
+
+    /**
+     * 판매중인 차량 가격, 설명을 수정합니다.
+     * 본인이 등록한 차량만 수정할 수 있습니다.
+     */
+    UpdateCarListingResponseDto updatePriceAndDesc(Long listingId, String userId, UpdateCarListingRequestDto dto);
+
+    /**
+     * 자신이 판매중인 차량과 관련 엔티티를 전부 삭제합니다.( soft delete )
+     */
+    void softDeleteCarListingWithRelatedEntities(Long listingId, String userId);
+
 }

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
@@ -1,10 +1,17 @@
 package com.yangsunkue.suncar.service.car;
 
+import com.yangsunkue.suncar.common.constant.ErrorMessages;
 import com.yangsunkue.suncar.dto.car.CarListingDto;
+import com.yangsunkue.suncar.dto.car.request.UpdateCarListingRequestDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
+import com.yangsunkue.suncar.dto.car.response.UpdateCarListingResponseDto;
 import com.yangsunkue.suncar.entity.car.CarListing;
+import com.yangsunkue.suncar.entity.user.User;
+import com.yangsunkue.suncar.exception.ForbiddenException;
+import com.yangsunkue.suncar.exception.NotFoundException;
 import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarListingRepository;
+import com.yangsunkue.suncar.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,5 +48,65 @@ public class CarListingServiceImpl implements CarListingService {
         CarListing saved = carListingRepository.save(carListing);
 
         return saved;
+    }
+
+    /**
+     * 판매중인 차량 가격, 설명을 수정합니다.
+     * 본인이 등록한 차량만 수정할 수 있습니다.
+     *
+     * @param listingId 차량 판매등록 ID
+     * @param userId 수정 요청자 로그인 아이디
+     * @param dto 수정 요청 Dto
+     */
+    @Override
+    @Transactional
+    public UpdateCarListingResponseDto updatePriceAndDesc(
+            Long listingId,
+            String userId,
+            UpdateCarListingRequestDto dto
+    ) {
+
+        /** 수정할 차량 찾기  */
+        CarListing target = carListingRepository.findById(listingId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
+
+        /** 본인의 차량인지 확인 */
+        if (!target.getUser().getUserId().equals(userId)) {
+            throw new ForbiddenException(ErrorMessages.NOT_OWNER_OF_CAR_LISTING);
+        }
+
+        /** 업데이트 */
+        target.patch(dto);
+
+        /** Dto로 변환 후 리턴 */
+        UpdateCarListingResponseDto updated = carMapper.toUpdateCarListingResponseDto(target);
+        return updated;
+    }
+
+    /**
+     * 판매중인 차량과 관련 엔티티를 전부 삭제합니다.( soft delete )
+     * 본인이 등록한 차량만 삭제할 수 있습니다.
+     *
+     * @param listingId 차량 판매등록 ID
+     * @param userId 삭제 요청자 로그인 아이디
+     */
+    @Override
+    @Transactional
+    public void softDeleteCarListingWithRelatedEntities(
+            Long listingId,
+            String userId
+    ) {
+
+        /** 수정할 차량 찾기  */
+        CarListing target = carListingRepository.findById(listingId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
+
+        /** 본인의 차량인지 확인 */
+        if (!target.getUser().getUserId().equals(userId)) {
+            throw new ForbiddenException(ErrorMessages.NOT_OWNER_OF_CAR_LISTING);
+        }
+
+        /** 판매중인 차량과 관련 엔티티 전부 삭제 */
+        carListingRepository.softDeleteCarListingWithRelatedEntities(listingId);
     }
 }


### PR DESCRIPTION
## 이슈 번호
- #43 

## 작업한 내용
- 판매 차량 수정 기능 추가
- 판매 차량 삭제 기능 추가
- 컨트롤러, 서비스, 기타 Dto 및 필요한 클래스 추가

## 설명
- 본인이 판매중인 차량의 가격, 판매설명 수정 가능
- 본인이 판매중인 차량 삭제 가능
-> 차량 삭제 커스텀 쿼리 작성: soft delete 방식으로 삭제하며, 연관된 모든 엔티티를 연쇄 삭제

## 비고
- 없음