### PR TITLE
Feat: 자신이 판매중인 차량 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/common/constant/ResponseMessages.java
+++ b/src/main/java/com/yangsunkue/suncar/common/constant/ResponseMessages.java
@@ -21,6 +21,7 @@ public class ResponseMessages {
      * Car 관련 응답 메시지
      */
     public static final String CAR_LIST_RETRIEVED = "차량 목록을 조회하였습니다.";
+    public static final String MY_CAR_LIST_RETRIEVED = "내 차량 목록을 조회하였습니다.";
     public static final String CAR_DETAIL_RETRIEVED = "판매 차량 상세정보를 조회하였습니다.";
     public static final String CAR_REGISTERED = "차량을 판매등록하였습니다.";
     public static final String CAR_DETAIL_UPDATED = "판매 차량 상세정보를 수정하였습니다.";

--- a/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
@@ -55,6 +55,29 @@ public class CarController {
     }
 
     /**
+     * 현재 사용자가 판매중인 차량 목록을 조회합니다.
+     */
+    @GetMapping("/me")
+    @SecurityRequirement(name = "bearer-jwt")
+    @Operation(summary = "현재 사용자의 판매 차량 목록 조회")
+    public ResponseDto<List<CarListResponseDto>> getMyCarList(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<CarListResponseDto> myCarList = carListingService.getCarListBySellerId(userDetails.getId());
+        return ResponseDto.of(ResponseMessages.MY_CAR_LIST_RETRIEVED, myCarList);
+    }
+
+    /**
+     * 판매 차량 상세정보를 조회합니다.
+     */
+    @GetMapping("/{listingId}")
+    @Operation(summary = "판매 차량 상세정보 조회")
+    public ResponseDto<CarDetailResponseDto> getCarDetail(@PathVariable Long listingId) {
+        CarDetailResponseDto carDetail = carFacadeDummyService.getCarDetail(listingId);
+        return ResponseDto.of(ResponseMessages.CAR_DETAIL_RETRIEVED, carDetail);
+    }
+
+    /**
      * 차량을 판매등록합니다. - 배포용
      */
 //    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -97,16 +120,6 @@ public class CarController {
 
         return ResponseEntity.created(URI.create("/cars/" + registeredCar.getListingId()))
                 .body(response);
-    }
-
-    /**
-     * 판매 차량 상세정보를 조회합니다.
-     */
-    @GetMapping("/{listingId}")
-    @Operation(summary = "판매 차량 상세정보 조회")
-    public ResponseDto<CarDetailResponseDto> getCarDetail(@PathVariable Long listingId) {
-        CarDetailResponseDto carDetail = carFacadeDummyService.getCarDetail(listingId);
-        return ResponseDto.of(ResponseMessages.CAR_DETAIL_RETRIEVED, carDetail);
     }
 
     /**

--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustom.java
@@ -13,8 +13,15 @@ public interface CarListingRepositoryCustom {
 
     /**
      * 모든 판매중인 자동차 정보를 찾습니다.
+     * sellerId 파라미터를 사용하는 getCarList() 메서드의 오버로딩 메서드입니다.
      */
     List<CarListResponseDto> getCarList();
+
+    /**
+     * 모든 판매중인 자동차 정보를 찾습니다.
+     * sellerId가 제공될 경우 해당 판매자의 차량만 조회합니다.
+     */
+    List<CarListResponseDto> getCarList(Long sellerId);
 
     /**
      * 차량 상세정보를 조회합니다.

--- a/src/main/java/com/yangsunkue/suncar/security/CustomUserDetails.java
+++ b/src/main/java/com/yangsunkue/suncar/security/CustomUserDetails.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 @ToString
 public class CustomUserDetails implements UserDetails {
 
+    private final Long id; // DB 레벨 아이디
     private final String userId; // 로그인 아이디
     private final String username; // 사용자 이름
     private final String password;

--- a/src/main/java/com/yangsunkue/suncar/security/CustomUserDetailsService.java
+++ b/src/main/java/com/yangsunkue/suncar/security/CustomUserDetailsService.java
@@ -29,6 +29,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new NotFoundException(ErrorMessages.USER_NOT_FOUND));
 
         return CustomUserDetails.builder()
+                .id(user.getId())
                 .userId(user.getUserId())
                 .username(user.getUsername())
                 .email(user.getEmail())

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingService.java
@@ -5,6 +5,7 @@ import com.yangsunkue.suncar.dto.car.request.UpdateCarListingRequestDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.UpdateCarListingResponseDto;
 import com.yangsunkue.suncar.entity.car.CarListing;
+import com.yangsunkue.suncar.security.CustomUserDetails;
 
 import java.util.List;
 
@@ -17,6 +18,11 @@ public interface CarListingService {
      * 판매중인 차량 목록을 조회합니다.
      */
     List<CarListResponseDto> getCarList();
+
+    /**
+     * 특정 판매자가 판매하는 차량 목록을 조회합니다.
+     */
+    List<CarListResponseDto> getCarListBySellerId(Long sellerId);
 
     /**
      * 차량 판매등록 정보를 생성합니다.

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
@@ -12,6 +12,7 @@ import com.yangsunkue.suncar.exception.NotFoundException;
 import com.yangsunkue.suncar.mapper.CarMapper;
 import com.yangsunkue.suncar.repository.car.CarListingRepository;
 import com.yangsunkue.suncar.repository.user.UserRepository;
+import com.yangsunkue.suncar.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,15 @@ public class CarListingServiceImpl implements CarListingService {
     @Override
     public List<CarListResponseDto> getCarList() {
         List<CarListResponseDto> carList = carListingRepository.getCarList();
+        return carList;
+    }
+
+    /**
+     * 특정 판매자가 판매하는 차량 목록을 조회합니다.
+     */
+    @Override
+    public List<CarListResponseDto> getCarListBySellerId(Long sellerId) {
+        List<CarListResponseDto> carList = carListingRepository.getCarList(sellerId);
         return carList;
     }
 


### PR DESCRIPTION
## 이슈 번호
- #45 

## 작업한 내용
- 자신이 판매중인 차량 목록 조회 기능 추가
- CustomUserDetails 클래스에 id 필드 추가 ( DB 레벨의 사용자 primary id )

## 설명
자신이 판매중인 차량 목록 조회 기능 추가
- 커스텀 쿼리를 이용한 단일 메서드로 구현
- 기존 차량 목록 조회 메서드가 영향받지 않도록, 필터링 여부로 갈리는 오버로딩 메서드로 구현
- soft delete 방식이라 엔티티 레벨의 cascade를 활용할 수 없었음. 따라서 커스텀 쿼리로 직접 구현
- CarListing 엔티티를 시작으로 연관된 모든 차량 정보 관련 엔티티 연쇄 삭제

CustomUserDetails 클래스에 id 필드 추가 ( DB 레벨의 사용자 primary id )
- 기존엔 id 필드가 없어, id를 얻으려면 repository를 한번 더 조회해야 하는 번거로움이 있었음
- id 필드를 추가하여 번거로움 개선

## 비고
- 없음