### PR TITLE
Fix: 삭제된 차량도 조회되는 현상 수정

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepositoryCustomImpl.java
@@ -87,8 +87,8 @@ public class CarListingRepositoryCustomImpl extends Querydsl4RepositorySupport i
                     JPAExpressions
                             .select(carMileage.id.max())
                             .from(carMileage)
-                            .groupBy(carMileage.car.id)
-            ));
+                            .groupBy(carMileage.car.id))
+                    .and(carListing.isDeleted.eq(false)));
 
         /** sellerId가 제공될 경우 필터링 추가 */
         if (sellerId != null) {
@@ -164,7 +164,8 @@ public class CarListingRepositoryCustomImpl extends Querydsl4RepositorySupport i
                 .join(carListing.car, car).fetchJoin()
                 .join(car.model, model).fetchJoin()
                 .join(carListing.user, user).fetchJoin()
-                .where(carListing.id.eq(listingId))
+                .where(carListing.id.eq(listingId)
+                        .and(carListing.isDeleted.eq(false)))
                 .fetchOne();
 
         if (result == null) {


### PR DESCRIPTION
## 이슈 번호
- #47 

## 작업한 내용
- 삭제된 차량이 조회되지 않게 수정 -> 조회 관련 커스텀 쿼리에 CarListing.isDeleted.eq(false) 조건절 추가

## 설명
- 기존 삭제 처리된 차량도 조회되던 것을 조회되지 않도록 수정

## 비고
- 없음