### PR TITLE
Refactor: 스프린트 4종료 코드 클린업

### DIFF
--- a/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/car/CarController.java
@@ -73,7 +73,7 @@ public class CarController {
     @GetMapping("/{listingId}")
     @Operation(summary = "판매 차량 상세정보 조회")
     public ResponseDto<CarDetailResponseDto> getCarDetail(@PathVariable Long listingId) {
-        CarDetailResponseDto carDetail = carFacadeDummyService.getCarDetail(listingId);
+        CarDetailResponseDto carDetail = carFacadeDummyService.getCarDetailById(listingId);
         return ResponseDto.of(ResponseMessages.CAR_DETAIL_RETRIEVED, carDetail);
     }
 
@@ -115,7 +115,7 @@ public class CarController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody RegisterCarDummyRequestDto dto
     ) {
-        RegisterCarResponseDto registeredCar = carFacadeDummyService.registerCar(dto, userDetails.getUserId());
+        RegisterCarResponseDto registeredCar = carFacadeDummyService.registerCar(dto, userDetails.getId());
         ResponseDto<RegisterCarResponseDto> response = ResponseDto.of(ResponseMessages.CAR_REGISTERED, registeredCar);
 
         return ResponseEntity.created(URI.create("/cars/" + registeredCar.getListingId()))
@@ -134,7 +134,7 @@ public class CarController {
             @PathVariable Long listingId,
             @RequestBody UpdateCarListingRequestDto dto
     ) {
-        UpdateCarListingResponseDto updated = carListingService.updatePriceAndDesc(listingId, userDetails.getUserId(), dto);
+        UpdateCarListingResponseDto updated = carListingService.updatePriceAndDesc(listingId, userDetails.getId(), dto);
         return ResponseDto.of(ResponseMessages.CAR_DETAIL_UPDATED, updated);
     }
 
@@ -149,7 +149,7 @@ public class CarController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long listingId
     ) {
-        carListingService.softDeleteCarListingWithRelatedEntities(listingId, userDetails.getUserId());
+        carListingService.softDeleteCarListingWithRelatedEntities(listingId, userDetails.getId());
         return ResponseDto.of(ResponseMessages.CAR_LISTING_DELETED);
     }
 }

--- a/src/main/java/com/yangsunkue/suncar/controller/user/UserController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/user/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserProfileUpdateRequestDto dto
     ) {
-        UserProfileResponseDto updatedProfile = userService.updateCurrentUserProfile(userDetails, dto);
+        UserProfileResponseDto updatedProfile = userService.updateCurrentUserProfile(userDetails.getId(), dto);
         return ResponseDto.of(ResponseMessages.USER_PROFILE_UPDATED, updatedProfile);
     }
 }

--- a/src/main/java/com/yangsunkue/suncar/dto/car/response/UpdateCarListingResponseDto.java
+++ b/src/main/java/com/yangsunkue/suncar/dto/car/response/UpdateCarListingResponseDto.java
@@ -1,17 +1,15 @@
 package com.yangsunkue.suncar.dto.car.response;
 
 import com.yangsunkue.suncar.dto.car.CarListingDto;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
 @Setter
+@Getter
 public class UpdateCarListingResponseDto extends CarListingDto {
 
-    private Long id;
+    private Long listingId;
 }

--- a/src/main/java/com/yangsunkue/suncar/entity/BaseEntity.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/BaseEntity.java
@@ -7,6 +7,9 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -21,7 +24,6 @@ import java.time.LocalDateTime;
  */
 @EntityListeners(AuditingEntityListener.class) // 엔티티 생성/수정 시간을 관리하는 리스너
 @MappedSuperclass // 이 클래스를 상속받은 엔티티들에게, DB 매핑정보를 제공하는 상위 클래스임을 나타낸다.
-@SQLRestriction("is_deleted = false") // 조회 시 삭제되지 않은 컬럼을 찾는 조건 추가
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/com/yangsunkue/suncar/entity/car/CarListing.java
+++ b/src/main/java/com/yangsunkue/suncar/entity/car/CarListing.java
@@ -6,6 +6,9 @@ import com.yangsunkue.suncar.entity.BaseEntity;
 import com.yangsunkue.suncar.entity.user.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import org.hibernate.annotations.SQLDelete;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
+++ b/src/main/java/com/yangsunkue/suncar/mapper/CarMapper.java
@@ -134,5 +134,6 @@ public interface CarMapper {
 
     @Mapping(source = "car.id", target = "carId")
     @Mapping(source = "user.id", target = "sellerId")
+    @Mapping(source = "id", target = "listingId")
     UpdateCarListingResponseDto toUpdateCarListingResponseDto(CarListing carListing);
 }

--- a/src/main/java/com/yangsunkue/suncar/repository/BaseRepository.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/BaseRepository.java
@@ -1,0 +1,21 @@
+package com.yangsunkue.suncar.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+@NoRepositoryBean
+public interface BaseRepository<T, ID> extends JpaRepository<T, ID> {
+
+    /**
+     * findById 메서드에 where 조건을 추가합니다.
+     * soft delete 되지 않은 데이터만 조회합니다.
+     * where is_delete = false
+     */
+    @Override
+    @Query("SELECT e FROM #{#entityName} e WHERE e.id = :id AND e.isDeleted = false")
+    Optional<T> findById(@Param("id") ID id);
+}

--- a/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepository.java
+++ b/src/main/java/com/yangsunkue/suncar/repository/car/CarListingRepository.java
@@ -1,7 +1,7 @@
 package com.yangsunkue.suncar.repository.car;
 
 import com.yangsunkue.suncar.entity.car.CarListing;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.yangsunkue.suncar.repository.BaseRepository;
 
-public interface CarListingRepository extends JpaRepository<CarListing, Long>, CarListingRepositoryCustom {
+public interface CarListingRepository extends BaseRepository<CarListing, Long>, CarListingRepositoryCustom {
 }

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingService.java
@@ -4,6 +4,7 @@ import com.yangsunkue.suncar.dto.car.CarListingDto;
 import com.yangsunkue.suncar.dto.car.request.UpdateCarListingRequestDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.UpdateCarListingResponseDto;
+import com.yangsunkue.suncar.dto.repository.CarDetailFetchResult;
 import com.yangsunkue.suncar.entity.car.CarListing;
 import com.yangsunkue.suncar.security.CustomUserDetails;
 
@@ -25,6 +26,14 @@ public interface CarListingService {
     List<CarListResponseDto> getCarListBySellerId(Long sellerId);
 
     /**
+     * 판매 차량 상세정보를 조회합니다.
+     * QueryDSL을 사용하여 데이터를 가져온 후, Facade 서비스에서 매퍼를 통해 DTO로 변환됩니다.
+     *
+     * @param listingId 차량 판매등록 ID
+     */
+    CarDetailFetchResult getCarDetailById(Long listingId);
+
+    /**
      * 차량 판매등록 정보를 생성합니다.
      */
     CarListing createListing(CarListingDto dto);
@@ -33,11 +42,11 @@ public interface CarListingService {
      * 판매중인 차량 가격, 설명을 수정합니다.
      * 본인이 등록한 차량만 수정할 수 있습니다.
      */
-    UpdateCarListingResponseDto updatePriceAndDesc(Long listingId, String userId, UpdateCarListingRequestDto dto);
+    UpdateCarListingResponseDto updatePriceAndDesc(Long listingId, Long userId, UpdateCarListingRequestDto dto);
 
     /**
      * 자신이 판매중인 차량과 관련 엔티티를 전부 삭제합니다.( soft delete )
      */
-    void softDeleteCarListingWithRelatedEntities(Long listingId, String userId);
+    void softDeleteCarListingWithRelatedEntities(Long listingId, Long userId);
 
 }

--- a/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/car/CarListingServiceImpl.java
@@ -3,8 +3,10 @@ package com.yangsunkue.suncar.service.car;
 import com.yangsunkue.suncar.common.constant.ErrorMessages;
 import com.yangsunkue.suncar.dto.car.CarListingDto;
 import com.yangsunkue.suncar.dto.car.request.UpdateCarListingRequestDto;
+import com.yangsunkue.suncar.dto.car.response.CarDetailResponseDto;
 import com.yangsunkue.suncar.dto.car.response.CarListResponseDto;
 import com.yangsunkue.suncar.dto.car.response.UpdateCarListingResponseDto;
+import com.yangsunkue.suncar.dto.repository.CarDetailFetchResult;
 import com.yangsunkue.suncar.entity.car.CarListing;
 import com.yangsunkue.suncar.entity.user.User;
 import com.yangsunkue.suncar.exception.ForbiddenException;
@@ -49,6 +51,19 @@ public class CarListingServiceImpl implements CarListingService {
     }
 
     /**
+     * 판매 차량 상세정보를 조회합니다.
+     * QueryDSL을 사용하여 데이터를 가져온 후, Facade 서비스에서 매퍼를 통해 DTO로 변환됩니다.
+     *
+     * @param listingId 차량 판매등록 ID
+     */
+    @Override
+    public CarDetailFetchResult getCarDetailById(Long listingId) {
+        CarDetailFetchResult data = carListingRepository.getCarDetailById(listingId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
+        return data;
+    }
+
+    /**
      * 차량 판매등록 정보를 생성합니다.
      */
     @Override
@@ -72,7 +87,7 @@ public class CarListingServiceImpl implements CarListingService {
     @Transactional
     public UpdateCarListingResponseDto updatePriceAndDesc(
             Long listingId,
-            String userId,
+            Long userId,
             UpdateCarListingRequestDto dto
     ) {
 
@@ -81,7 +96,7 @@ public class CarListingServiceImpl implements CarListingService {
                 .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
 
         /** 본인의 차량인지 확인 */
-        if (!target.getUser().getUserId().equals(userId)) {
+        if (!target.getUser().getId().equals(userId)) {
             throw new ForbiddenException(ErrorMessages.NOT_OWNER_OF_CAR_LISTING);
         }
 
@@ -104,15 +119,15 @@ public class CarListingServiceImpl implements CarListingService {
     @Transactional
     public void softDeleteCarListingWithRelatedEntities(
             Long listingId,
-            String userId
+            Long userId
     ) {
 
-        /** 수정할 차량 찾기  */
+        /** 삭제할 차량 찾기  */
         CarListing target = carListingRepository.findById(listingId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
 
         /** 본인의 차량인지 확인 */
-        if (!target.getUser().getUserId().equals(userId)) {
+        if (!target.getUser().getId().equals(userId)) {
             throw new ForbiddenException(ErrorMessages.NOT_OWNER_OF_CAR_LISTING);
         }
 

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeBaseService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeBaseService.java
@@ -18,5 +18,5 @@ public interface CarFacadeBaseService {
     /**
      * 판매 차량 상세정보를 조회합니다.
      */
-    CarDetailResponseDto getCarDetail(Long listingId);
+    CarDetailResponseDto getCarDetailById(Long listingId);
 }

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyService.java
@@ -12,5 +12,5 @@ public interface CarFacadeDummyService extends CarFacadeBaseService {
     /**
      * 차량을 판매등록합니다. - 더미 데이터 입력을 위한 메서드 입니다.
      */
-    RegisterCarResponseDto registerCar(RegisterCarDummyRequestDto dto, String userId);
+    RegisterCarResponseDto registerCar(RegisterCarDummyRequestDto dto, Long userId);
 }

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeDummyServiceImpl.java
@@ -36,9 +36,6 @@ public class CarFacadeDummyServiceImpl implements CarFacadeDummyService {
     private final CarDummyDataGenerator carDummyDataGenerator;
     private final CarMapper carMapper;
 
-    private final UserRepository userRepository;
-    private final CarListingRepository carListingRepository;
-
     /** Car 관련 서비스 */
     private final ModelService modelService;
     private final CarService carService;
@@ -67,11 +64,10 @@ public class CarFacadeDummyServiceImpl implements CarFacadeDummyService {
      * @param listingId 차량 판매등록 ID
      */
     @Override
-    public CarDetailResponseDto getCarDetail(Long listingId) {
+    public CarDetailResponseDto getCarDetailById(Long listingId) {
 
         /** 차량 상세정보 엔티티들 조회 */
-        CarDetailFetchResult data = carListingRepository.getCarDetailById(listingId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
+        CarDetailFetchResult data = carListingService.getCarDetailById(listingId);
 
         /** DTO로 변환 */
         CarDetailResponseDto carDetail = carMapper.toCarDetailResponseDto(data.carListing());
@@ -97,7 +93,7 @@ public class CarFacadeDummyServiceImpl implements CarFacadeDummyService {
      */
     @Override
     @Transactional
-    public RegisterCarResponseDto registerCar(RegisterCarDummyRequestDto dto, String userId) {
+    public RegisterCarResponseDto registerCar(RegisterCarDummyRequestDto dto, Long userId) {
 
         /**
          * 각 엔티티마다 더미 데이터 생성 후 DB에 저장
@@ -115,11 +111,7 @@ public class CarFacadeDummyServiceImpl implements CarFacadeDummyService {
          * CarListing
          * - 차량 등록 요청자 id를 인자로 전달
          */
-        User user = userRepository.findByUserId(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessages.USER_NOT_FOUND));
-        Long userPrimaryId = user.getId();
-
-        CarListingDto listingDto = carDummyDataGenerator.generateCarListingDto(car.getId(), userPrimaryId, dto.getPrice());
+        CarListingDto listingDto = carDummyDataGenerator.generateCarListingDto(car.getId(), userId, dto.getPrice());
         CarListing listing = carListingService.createListing(listingDto);
 
         /** CarAccident */

--- a/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/facade/CarFacadeServiceImpl.java
@@ -49,11 +49,10 @@ public class CarFacadeServiceImpl implements CarFacadeService {
      * @param listingId 차량 판매등록 ID
      */
     @Override
-    public CarDetailResponseDto getCarDetail(Long listingId) {
+    public CarDetailResponseDto getCarDetailById(Long listingId) {
 
         /** 차량 상세정보 엔티티들 조회 */
-        CarDetailFetchResult data = carListingRepository.getCarDetailById(listingId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessages.CAR_LISTING_NOT_FOUND));
+        CarDetailFetchResult data = carListingService.getCarDetailById(listingId);
 
         /** DTO로 변환 */
         CarDetailResponseDto carDetail = carMapper.toCarDetailResponseDto(data.carListing());

--- a/src/main/java/com/yangsunkue/suncar/service/user/UserService.java
+++ b/src/main/java/com/yangsunkue/suncar/service/user/UserService.java
@@ -10,7 +10,7 @@ public interface UserService {
      * 현재 사용자 정보를 수정합니다.
      */
     UserProfileResponseDto updateCurrentUserProfile(
-            CustomUserDetails userDetails,
+            Long userId,
             UserProfileUpdateRequestDto dto
     );
 }

--- a/src/main/java/com/yangsunkue/suncar/service/user/UserServiceImpl.java
+++ b/src/main/java/com/yangsunkue/suncar/service/user/UserServiceImpl.java
@@ -26,10 +26,10 @@ public class UserServiceImpl implements UserService{
     @Override
     @Transactional
     public UserProfileResponseDto updateCurrentUserProfile(
-            CustomUserDetails userDetails,
+            Long userId,
             UserProfileUpdateRequestDto dto
     ) {
-        User currentUser = userRepository.findByUserId(userDetails.getUserId())
+        User currentUser = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessages.USER_NOT_FOUND));
 
         // 사용자 정보 수정


### PR DESCRIPTION
## 이슈 번호
- #49 

## 작업한 내용
메서드명 기능에 맞도록 수정
- CarFacadeDummyServiceImpl 구현체  getCarDetail() 메서드를 기능과 일치하도록 -> getCarDetailById() 로 변경
- 직접 repository 호출하던 것을 서비스 계층을 거치도록 계층 추가
- 관련 메서드, 테스트 코드 모두 수정

비효율적인 로직 수정
- CustomUserDetail에 id 필드가 추가됨에 따라 기존 userId로 repository를 조회하여 id를 가져오는 비효율적인 로직 제거
- 관련 메서드, 테스트 코드 모두 수정

삭제된 데이터도 조회되는 버그 수정
- soft delete된 데이터도 조회되는 현상 발생
- BaseRepository 추가하여 findById() 오버라이드, is_delete=false 데이터만 조회하게 함

## 설명
- 스프린트 4 종료에 따른 코드 클린업, 리팩토링 및 간단한 버그 수정 작업

## 비고
- 없음