### PR TITLE
Feat: 애플리케이션 health check 관련 엔드포인트 추가 (무중단 배포 파이프라인에서 활용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,8 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
-
+	// Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 // Querydsl 설정

--- a/src/main/java/com/yangsunkue/suncar/config/SecurityConfig.java
+++ b/src/main/java/com/yangsunkue/suncar/config/SecurityConfig.java
@@ -42,7 +42,9 @@ public class SecurityConfig {
                                 "/api-docs/**",
                                 "/swagger-ui/**",
                                 "/auth/**",
-                                "/cars/**"
+                                "/cars/**",
+                                "/serverProfile",
+                                "/actuator/**"
                         ).permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/yangsunkue/suncar/controller/server/ServerController.java
+++ b/src/main/java/com/yangsunkue/suncar/controller/server/ServerController.java
@@ -1,0 +1,26 @@
+package com.yangsunkue.suncar.controller.server;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 서버레벨 데이터 조회를 담당하는 컨트롤러 입니다.
+ */
+@RestController
+public class ServerController {
+
+    @Autowired
+    private Environment env;
+
+    /**
+     * 현재 서버가 사용중인 포트번호를 반환합니다.
+     *
+     * @return 현재 사용중인 포트번호
+     */
+    @GetMapping("/serverProfile")
+    public String getServerProfile() {
+        return env.getProperty("server.port", "8080");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,7 @@ spring.profiles.active=dev
 
 # BatchSize
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
+
+# Actuator
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always


### PR DESCRIPTION
## 이슈 번호
- #53 

## 작업한 내용
현재 서버가 사용중인 포트 반환하는 엔드포인트 추가
- 컨트롤러, 메서드 추가 (ServerController, getServerProfile())

현재 서버의 가동 상태 체크하는 엔드포인트 추가
- actuator 의존성 추가 (build.gradle)
- actuator 설정 추가 (application.properties)

스프링 시큐리티 필터 체인 수정
- health check 관련 엔드포인트 권한 없이 접근 가능하도록 수정
- /serverProfile , /actuator/** 필터 체인에 추가

## 설명
- Jenkins와 Blue/Green 배포 전략을 활용한 CI/CD 무중단 배포 파이프라인 구축에서 활용할 애플리케이션 health check 관련 엔드포인트 및 의존성 추가

## 비고
- 없음